### PR TITLE
fix casting for llb.Readonly to force llb.Mountoption to prevent panic

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -1301,7 +1301,7 @@ func emitMountOptions(info *CodeGenInfo, scope *ast.Scope, op string, stmts []*a
 					return opts, err
 				}
 				if v {
-					opts = append(opts, llb.Readonly)
+					opts = append(opts, llb.MountOption(llb.Readonly))
 				}
 			case "tmpfs":
 				v, err := maybeEmitBoolExpr(info, scope, args)


### PR DESCRIPTION
in codegen.go you have:
```
                for _, iopt := range iopts {
                    opt := iopt.(llb.MountOption)
                    mountOpts = append(mountOpts, opt)
                }
```
but llb.Readonly is type `func(*mount)`, so it needs to be cast explicitly.  Otherwise we get this panic:
```
interface conversion: interface {} is func(*llb.mount), not llb.MountOption
```