### PR TITLE
Expose more granular CST nodes for import/export

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -119,8 +119,8 @@ func (c *checker) Check(mod *parser.Module) error {
 		case *parser.ImportDecl:
 			imp := n
 
-			if n.Import != nil {
-				err := c.checkFuncLitArg(mod.Scope, parser.Filesystem, imp.Import)
+			if n.ImportFunc != nil {
+				err := c.checkFuncLitArg(mod.Scope, parser.Filesystem, imp.ImportFunc.Func)
 				if err != nil {
 					c.errs = append(c.errs, err)
 				}

--- a/module/tree.go
+++ b/module/tree.go
@@ -46,13 +46,13 @@ func NewTree(ctx context.Context, cln *client.Client, mw *progress.MultiWriter, 
 
 		var value string
 		switch {
-		case decl.Import != nil:
+		case decl.ImportFunc != nil:
 			value = filepath.Join(prefix, ModuleFilename)
-		case decl.LocalImport != nil:
+		case decl.ImportPath != nil:
 			if prefix == "" {
-				value = *decl.LocalImport
+				value = decl.ImportPath.Path
 			} else {
-				value = filepath.Join(prefix, *decl.LocalImport)
+				value = filepath.Join(prefix, decl.ImportPath.Path)
 			}
 		}
 

--- a/module/vendor.go
+++ b/module/vendor.go
@@ -99,10 +99,10 @@ func Vendor(ctx context.Context, cln *client.Client, mw *progress.MultiWriter, m
 
 			var filename string
 			switch {
-			case decl.Import != nil:
+			case decl.ImportFunc != nil:
 				filename = ModuleFilename
-			case decl.LocalImport != nil:
-				filename = *decl.LocalImport
+			case decl.ImportPath != nil:
+				filename = decl.ImportPath.Path
 			}
 
 			f, err := os.Create(filepath.Join(vp, filename))

--- a/parser/unparse.go
+++ b/parser/unparse.go
@@ -101,17 +101,41 @@ func (d *Decl) String() string {
 }
 
 func (d *ImportDecl) String() string {
+	var value string
 	switch {
-	case d.Import != nil:
-		return fmt.Sprintf("import %s from %s", d.Ident, d.Import)
-	case d.LocalImport != nil:
-		return fmt.Sprintf("import %s %s", d.Ident, strconv.Quote(*d.LocalImport))
+	case d.ImportFunc != nil:
+		value = d.ImportFunc.String()
+	case d.ImportPath != nil:
+		value = d.ImportPath.String()
+	default:
+		panic("unknown import decl")
 	}
-	panic("unknown import decl")
+
+	return fmt.Sprintf("%s %s %s", d.Import, d.Ident, value)
+}
+
+func (i *Import) String() string {
+	return i.Keyword
+}
+
+func (i *ImportFunc) String() string {
+	return fmt.Sprintf("%s %s", i.From, i.Func)
+}
+
+func (f *From) String() string {
+	return f.Keyword
+}
+
+func (ip *ImportPath) String() string {
+	return strconv.Quote(ip.Path)
 }
 
 func (d *ExportDecl) String() string {
-	return fmt.Sprintf("export %s", d.Ident)
+	return fmt.Sprintf("%s %s", d.Export, d.Ident)
+}
+
+func (e *Export) String() string {
+	return e.Keyword
 }
 
 func (d *FuncDecl) String() string {

--- a/parser/walk.go
+++ b/parser/walk.go
@@ -39,8 +39,15 @@ func Walk(node Node, v Visitor) {
 		if n.Ident != nil {
 			Walk(n.Ident, v)
 		}
-		if n.Import != nil {
-			Walk(n.Import, v)
+		if n.ImportFunc != nil {
+			Walk(n.ImportFunc, v)
+		}
+		if n.ImportPath != nil {
+			Walk(n.ImportPath, v)
+		}
+	case *ImportFunc:
+		if n.Func != nil {
+			Walk(n.Func, v)
 		}
 	case *ExportDecl:
 		if n.Ident != nil {


### PR DESCRIPTION
Necessary to highlight the keywords `import`, `export`, `from`, and the import path for local imports.