### PR TITLE
Touchup module and parser packages, and use imports to break up source.hlb

### DIFF
--- a/go.hlb
+++ b/go.hlb
@@ -1,0 +1,64 @@
+export binary
+
+export crossBinaries
+
+export lint
+
+fs build(fs src, string package) {
+	image "golang:1.14-alpine"
+	run "apk add -U git gcc libc-dev"
+	env "GO111MODULE" "on"
+	dir "/go/src/hlb"
+	run string {
+		format "/usr/local/go/bin/go build -o /out/binary -ldflags '-linkmode external -extldflags -static' -a %s" package
+	} with option {
+		cacheMounts src
+		mount fs { scratch; } "/out" as binary
+	}
+}
+
+fs crossBuild(fs src, string package) {
+	image "dockercore/golang-cross:1.12.5" with option { resolve; }
+	env "GOPATH" "/root/go"
+	env "GO111MODULE" "on"
+	dir "/go/src/hlb"
+	run "/cross/build" package with option {
+		cacheMounts src
+		mount fs { git "https://github.com/hinshun/go-cross.git" ""; } "/cross" with option {
+			sourcePath "/scripts"
+			readonly
+		}
+		mount fs { scratch; } "/root/go/bin" as crossBinaries
+	}
+}
+
+fs lint(fs src) {
+	image "golang:1.14-alpine"
+	run "apk add -U git gcc libc-dev"
+	run "sh /golangci/install.sh -b /usr/bin v1.23.8" with option {
+		mount fs {
+			http "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
+		} "/golangci"
+	}
+	env "GO111MODULE" "on"
+	env "PATH" "/usr/bin:/bin:/usr/local/go/bin"
+	dir "/go/src/hlb"
+	run "go get" with option {
+		cacheMounts src
+	}
+	run "/usr/bin/golangci-lint run" with option {
+		cacheMounts src
+	}
+}
+
+option::run cacheMounts(fs src) {
+	mount src "/go/src/hlb" with option {
+		readonly
+	}
+	mount fs { scratch; } "/root/.cache/go-build" with option {
+		cache "hlb/go-build" "private"
+	}
+	mount fs { scratch; } "/go/pkg/mod" with option {
+		cache "hlb/go-mod" "private"
+	}
+}

--- a/module/resolve.go
+++ b/module/resolve.go
@@ -130,11 +130,7 @@ func resolveLocal(ctx context.Context, scope *parser.Scope, lit *parser.FuncLit,
 		return nil, err
 	}
 
-	vp, err := VendorPath(modulePath, dgst)
-	if err != nil {
-		return nil, err
-	}
-
+	vp := VendorPath(modulePath, dgst)
 	return &localResolved{dgst, vp}, nil
 }
 
@@ -345,9 +341,9 @@ func (r *targetResolver) Resolve(ctx context.Context, scope *parser.Scope, decl 
 // VendorPath returns a modules path based on the digest of marshalling the
 // LLB. This digest is stable even when the underlying remote sources change
 // contents, for example `alpine:latest` may be pushed to.
-func VendorPath(root string, dgst digest.Digest) (string, error) {
+func VendorPath(root string, dgst digest.Digest) string {
 	encoded := dgst.Encoded()
-	return filepath.Join(root, dgst.Algorithm().String(), encoded[:2], encoded), nil
+	return filepath.Join(root, dgst.Algorithm().String(), encoded[:2], encoded)
 }
 
 // Visitor is a callback invoked for every import when traversing the import

--- a/module/vendor.go
+++ b/module/vendor.go
@@ -69,10 +69,7 @@ func Vendor(ctx context.Context, cln *client.Client, mw *progress.MultiWriter, m
 				}
 			}
 
-			vp, err := VendorPath(root, dgst)
-			if err != nil {
-				return err
-			}
+			vp := VendorPath(root, dgst)
 
 			// If tidy mode is enabled, then we mark imported modules during graph
 			// traversal, and then sweep unused vendored modules.
@@ -92,7 +89,7 @@ func Vendor(ctx context.Context, cln *client.Client, mw *progress.MultiWriter, m
 				}
 			}
 
-			err = os.MkdirAll(vp, 0700)
+			err := os.MkdirAll(vp, 0700)
 			if err != nil {
 				return err
 			}

--- a/parser/cst.go
+++ b/parser/cst.go
@@ -54,7 +54,7 @@ type Node interface {
 // represents a module.
 //
 // Initially, the Parser will fill in this struct as a parse tree / concrete
-// syntax tree, but a second pass from the Analyzer will type check and fill in
+// syntax tree, but a second pass from the Checker will type check and fill in
 // fields without parser struct tags like scopes and doc linking.
 type Module struct {
 	Pos   lexer.Position
@@ -338,25 +338,12 @@ func (t *Type) Equals(typ ObjType) bool {
 type ObjType string
 
 const (
-	None           ObjType = ""
-	Str            ObjType = "string"
-	Int            ObjType = "int"
-	Bool           ObjType = "bool"
-	Filesystem     ObjType = "fs"
-	Option         ObjType = "option"
-	OptionImage    ObjType = "option::image"
-	OptionHTTP     ObjType = "option::http"
-	OptionGit      ObjType = "option::git"
-	OptionLocal    ObjType = "option::local"
-	OptionGenerate ObjType = "option::generate"
-	OptionRun      ObjType = "option::run"
-	OptionSSH      ObjType = "option::ssh"
-	OptionSecret   ObjType = "option::secret"
-	OptionMount    ObjType = "option::mount"
-	OptionMkdir    ObjType = "option::mkdir"
-	OptionMkfile   ObjType = "option::mkfile"
-	OptionRm       ObjType = "option::rm"
-	OptionCopy     ObjType = "option::copy"
+	None       ObjType = ""
+	Str        ObjType = "string"
+	Int        ObjType = "int"
+	Bool       ObjType = "bool"
+	Filesystem ObjType = "fs"
+	Option     ObjType = "option"
 )
 
 // Ident represents an identifier.

--- a/parser/unparse.go
+++ b/parser/unparse.go
@@ -62,6 +62,7 @@ func (m *Module) String() string {
 		prevDecl = str
 	}
 
+	var sep string
 	if hasNewline {
 		// Strip trailing newlines
 		for i := len(decls) - 1; i > 0; i-- {
@@ -71,11 +72,11 @@ func (m *Module) String() string {
 				break
 			}
 		}
-
-		return fmt.Sprintf("%s%s", doc, strings.Join(decls, ""))
 	} else {
-		return fmt.Sprintf("%s%s", doc, strings.Join(decls, " "))
+		sep = " "
 	}
+
+	return fmt.Sprintf("%s%s", doc, strings.Join(decls, sep))
 }
 
 func (b *Bad) String() string {

--- a/source.hlb
+++ b/source.hlb
@@ -1,24 +1,15 @@
+import go "./go.hlb"
+
 fs default() {
 	crossHLB
 }
 
 fs crossHLB() {
-	crossBinaries "github.com/openllb/hlb/cmd/hlb"
+	go.crossBinaries src "github.com/openllb/hlb/cmd/hlb"
 }
 
-fs crossBuild(string package) {
-	image "dockercore/golang-cross:1.12.5" with option { resolve; }
-	env "GOPATH" "/root/go"
-	env "GO111MODULE" "on"
-	dir "/go/src/hlb"
-	run "/cross/build" package with option {
-		goCacheMounts
-		mount fs { git "https://github.com/hinshun/go-cross.git" ""; } "/cross" with option {
-			sourcePath "/scripts"
-			readonly
-		}
-		mount fs { scratch; } "/root/go/bin" as crossBinaries
-	}
+fs lint() {
+	go.lint src
 }
 
 fs src() {
@@ -26,56 +17,3 @@ fs src() {
 		excludePatterns ".git" "build"
 	}
 }
-
-option::run goCacheMounts() {
-	mount src "/go/src/hlb" with option {
-		readonly
-	}
-	mount fs { scratch; } "/root/.cache/go-build" with option {
-		cache "hlb/go-build" "private"
-	}
-	mount fs { scratch; } "/go/pkg/mod" with option {
-		cache "hlb/go-mod" "private"
-	}
-}
-
-fs goLint() {
-	image "golang:1.14-alpine"
-	run "apk add -U git gcc libc-dev"
-	run "sh /golangci/install.sh -b /usr/bin v1.23.8" with option {
-		mount fs {
-			http "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
-		} "/golangci"
-	}
-	env "GO111MODULE" "on"
-	env "PATH" "/usr/bin:/bin:/usr/local/go/bin"
-	dir "/go/src/hlb"
-	run "go get" with option {
-		goCacheMounts
-	}
-	run "/usr/bin/golangci-lint run" with option {
-		goCacheMounts
-	}
-}
-
-fs goBuild(string package) {
-	image "golang:1.14-alpine"
-	run "apk add -U git gcc libc-dev"
-	env "GO111MODULE" "on"
-	dir "/go/src/hlb"
-	breakpoint
-	run string {
-		format "/usr/local/go/bin/go build -o /out/binary -ldflags '-linkmode external -extldflags -static' -a %s" package
-	} with option {
-		goCacheMounts
-		mount fs { scratch; } "/out" as goBinary
-	}
-}
-
-fs hlbFrontend() {
-	scratch
-	copy fs { goBinary "./cmd/frontend"; } "/binary" "/run"
-	copy src "/source.hlb" "/"
-	copy src "/signature.hlb" "/"
-}
-


### PR DESCRIPTION
- Did some touchups in packages `module` and `parser`.
- Broke up `source.hlb` into `go.hlb` using  relative imports