### PR TITLE
add version command and infer version from git tag

### DIFF
--- a/cmd/hlb/command/app.go
+++ b/cmd/hlb/command/app.go
@@ -30,6 +30,7 @@ func App() *cli.App {
 	}
 
 	app.Commands = []*cli.Command{
+		versionCommand,
 		runCommand,
 		formatCommand,
 		moduleCommand,

--- a/cmd/hlb/command/version.go
+++ b/cmd/hlb/command/version.go
@@ -1,0 +1,17 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/openllb/hlb"
+	cli "github.com/urfave/cli/v2"
+)
+
+var versionCommand = &cli.Command{
+	Name:  "version",
+	Usage: "prints hlb tool version",
+	Action: func(c *cli.Context) error {
+		fmt.Println(hlb.Version)
+		return nil
+	},
+}

--- a/go.hlb
+++ b/go.hlb
@@ -4,25 +4,31 @@ export crossBinaries
 
 export lint
 
-fs build(fs src, string package) {
+string versionCmd() {
+	format "git describe --match 'v[0-9]*' --tags --dirty='.dirty' --always | sed 's/^v//'"
+}
+
+fs build(fs src, string package, string verPackage) {
 	image "golang:1.14-alpine"
 	run "apk add -U git gcc libc-dev"
 	env "GO111MODULE" "on"
 	dir "/go/src/hlb"
 	run string {
-		format "/usr/local/go/bin/go build -o /out/binary -ldflags '-linkmode external -extldflags -static' -a %s" package
+		format "v=$(%s) && /usr/local/go/bin/go build -o /out/binary -ldflags \"-linkmode external -extldflags -static -X %s.Version=$v\" -a %s" string { versionCmd; }  package verPackage
 	} with option {
 		cacheMounts src
 		mount fs { scratch; } "/out" as binary
 	}
 }
 
-fs crossBuild(fs src, string package) {
+fs crossBuild(fs src, string package, string verPackage) {
 	image "dockercore/golang-cross:1.12.5" with option { resolve; }
 	env "GOPATH" "/root/go"
 	env "GO111MODULE" "on"
 	dir "/go/src/hlb"
-	run "/cross/build" package with option {
+	run string {
+		format "v=$(%s) && LDFLAGS=\"-X %s.Version=$v\" /cross/build %q" string { versionCmd; } verPackage package 
+	} with option {
 		cacheMounts src
 		mount fs { git "https://github.com/hinshun/go-cross.git" ""; } "/cross" with option {
 			sourcePath "/scripts"

--- a/source.hlb
+++ b/source.hlb
@@ -5,7 +5,7 @@ fs default() {
 }
 
 fs crossHLB() {
-	go.crossBinaries src "github.com/openllb/hlb/cmd/hlb"
+	go.crossBinaries src "github.com/openllb/hlb/cmd/hlb" "github.com/openllb/hlb"
 }
 
 fs lint() {
@@ -14,6 +14,6 @@ fs lint() {
 
 fs src() {
 	local "." with option {
-		excludePatterns ".git" "build"
+		excludePatterns "build"
 	}
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package hlb
+
+var Version = "0.1+unknown"


### PR DESCRIPTION
Fixes issues #10 

This uses the git tag + distance to version the binary.  It adds an `hlb version` command which will print something like:
```
$ build/hlb-darwin-amd64 version
0.1-43-gf1453b1
```
The `0.1` is from the version tag, the `43` is the distances in commits since the version tag, and the `gf1453b1` is a `g` plus the git sha for HEAD.  The version string is derived from `git describe --tags --always`.  The version will have an extra `.dirty` on the end if it was compiled from modified sources.

I am not happy with the changes necessary to the `go.hlb` file, but I could not figure out anything better.   At least it seems to work.