### PR TITLE
[#32] return error when requested target is not defined

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,10 @@ jobs:
     - name: Start BuildkitD
       run: docker run --name buildkitd --rm -d --privileged openllb/buildkit:experimental
 
+    - name: BuildkitD Wait
+      # waiting for buildkitd to report 1 worker (2 lines, 1 for column titles, one for the worker details)
+      run: while true; do lineCount=$(docker exec buildkitd buildctl debug workers | wc -l); if [ $lineCount -gt 1 ]; then break; fi; sleep 1; done
+
     - name: GoLint
       run: ./build/hlb --addr docker-container://buildkitd run --log-output plain -t lint ./source.hlb
 

--- a/hlb.go
+++ b/hlb.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/alecthomas/participle/lexer"
 	"github.com/docker/buildx/util/progress"
 	isatty "github.com/mattn/go-isatty"
 	"github.com/moby/buildkit/client"
@@ -40,6 +41,15 @@ func Compile(ctx context.Context, cln *client.Client, mw *progress.MultiWriter, 
 	err = checker.Check(mod)
 	if err != nil {
 		return st, nil, err
+	}
+
+	obj := mod.Scope.Lookup(target)
+	if obj == nil {
+		name := lexer.NameOfReader(r)
+		if name == "" {
+			name = "<stdin>"
+		}
+		return st, nil, fmt.Errorf("target %q is not defined in %s", target, name)
 	}
 
 	resolver, err := module.NewResolver(cln, mw)


### PR DESCRIPTION
Fixes issue #32

This is what we will see now:
```
$ ./hlb --addr docker-container://buildkitd run --target bogus ./source.hlb
target "bogus" is not defined in ./source.hlb
```
```
$ cat ./source.hlb | ./hlb --addr docker-container://buildkitd run --target bogus
target "bogus" is not defined in /dev/stdin
```