### PR TITLE
[#43] plumb secret imports through to llb client

### DIFF
--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -157,6 +157,9 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, opts RunOpti
 	for id, path := range info.Locals {
 		solveOpts = append(solveOpts, solver.WithLocal(id, path))
 	}
+	for id, path := range info.Secrets {
+		solveOpts = append(solveOpts, solver.WithSecret(id, path))
+	}
 
 	if opts.Download != "" {
 		solveOpts = append(solveOpts, solver.WithDownload(opts.Download))

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -18,8 +18,9 @@ import (
 )
 
 type CodeGen struct {
-	Debug  Debugger
-	Locals map[string]string
+	Debug   Debugger
+	Locals  map[string]string
+	Secrets map[string]string
 }
 
 type CodeGenOption func(*CodeGen) error
@@ -33,8 +34,9 @@ func WithDebugger(dbgr Debugger) CodeGenOption {
 
 func New(opts ...CodeGenOption) (*CodeGen, error) {
 	cg := &CodeGen{
-		Debug:  NewNoopDebugger(),
-		Locals: make(map[string]string),
+		Debug:   NewNoopDebugger(),
+		Locals:  make(map[string]string),
+		Secrets: make(map[string]string),
 	}
 	for _, opt := range opts {
 		err := opt(cg)
@@ -1152,12 +1154,22 @@ func (cg *CodeGen) EmitExecOptions(ctx context.Context, scope *parser.Scope, op 
 
 				opts = append(opts, llb.AddSSHSocket(sshOpts...))
 			case "secret":
-				target, err := cg.EmitStringExpr(ctx, scope, stmt.Call, args[0])
+				input, err := cg.EmitStringExpr(ctx, scope, stmt.Call, args[0])
 				if err != nil {
 					return opts, err
 				}
 
-				var secretOpts []llb.SecretOption
+				target, err := cg.EmitStringExpr(ctx, scope, stmt.Call, args[1])
+				if err != nil {
+					return opts, err
+				}
+
+				id := string(digest.FromString(input))
+				cg.Secrets[id] = input
+
+				secretOpts := []llb.SecretOption{
+					llb.SecretID(id),
+				}
 				for _, iopt := range iopts {
 					opt := iopt.(llb.SecretOption)
 					secretOpts = append(secretOpts, opt)


### PR DESCRIPTION
fixes #43 

Example input:
```
$ cat ./tests/bug.hlb
fs secretTest() {
  image "busybox:latest"
  dir "/dir"
  run "ls" with option {
    secret "./tests/bug.hlb" "/dir/bug.hlb"
  }
}
```

```
$ ./hlb run -t secretTest --log-output plain ./tests/bug.hlb
#1 compiling ./tests/bug.hlb
#1 DONE 0.0s

#2 docker-image://docker.io/library/busybox:latest
#2 resolve docker.io/library/busybox:latest
#2 resolve docker.io/library/busybox:latest 1.1s done
#2 sha256:b26cd013274a657b86e706210ddd5cc1f82f50155791199d29b9e86e935ce135 1.86kB / 1.86kB done
#2 sha256:afe605d272837ce1732f390966166c2afff5391208ddd57de10942748694049d 527B / 527B done
#2 sha256:0669b0daf1fba90642d105f3bc2c94365c5282155a33cc65ac946347a90d90d1 0B / 760.80kB 0.1s
#2 sha256:83aa35aa1c79e4b6957e018da6e322bfca92bf3b4696a211b42502543c242d6f 1.49kB / 1.49kB done
#2 sha256:0669b0daf1fba90642d105f3bc2c94365c5282155a33cc65ac946347a90d90d1 760.80kB / 760.80kB 0.3s done
#2 unpacking docker.io/library/busybox:latest 0.1s done
#2 DONE 0.4s

#3 /bin/sh -c cat bug.hlb
#3 0.094 fs secretTest() {
#3 0.094   image "busybox:latest"
#3 0.094   dir "/dir"
#3 0.094   run "cat bug.hlb" with option {
#3 0.094     secret "./tests/bug.hlb" "/dir/bug.hlb"
#3 0.094   }
#3 0.094 }
#3 DONE 0.3s
```