### PR TITLE
[#40] fix usage of `with myoption`

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -425,6 +425,12 @@ func (cg *CodeGen) EmitWithOption(ctx context.Context, scope *parser.Scope, pare
 		switch obj.Kind {
 		case parser.ExprKind:
 			return obj.Data.([]interface{}), nil
+		case parser.DeclKind:
+			if n, ok := obj.Node.(*parser.FuncDecl); ok {
+				return cg.EmitOptions(ctx, scope, parent.Func.Ident.Name, n.Body.NonEmptyStmts(), ac)
+			} else {
+				panic("unknown decl type")
+			}
 		default:
 			panic("unknown with option kind")
 		}


### PR DESCRIPTION
fixes #40 

Input:
```
fs issue40() {
  image "alpine:latest"
  run "pwd" with myopt
}

option::run myopt() {
  dir "/etc"
}
```

Output:
```
$ ./hlb run -t issue40 --log-output plain ./tests/bug.hlb
#1 compiling ./tests/bug.hlb
#1 DONE 0.0s

#2 docker-image://docker.io/library/alpine:latest
#2 resolve docker.io/library/alpine:latest
#2 resolve docker.io/library/alpine:latest 0.7s done
#2 DONE 0.7s

#2 docker-image://docker.io/library/alpine:latest
#2 CACHED

#3 pwd
#3 0.101 /etc
#3 DONE 0.1s
```