### PR TITLE
[#52] fix stack overflow when using alias within same fs

### DIFF
--- a/codegen/decl.go
+++ b/codegen/decl.go
@@ -78,10 +78,12 @@ func (cg *CodeGen) EmitStringFuncDecl(ctx context.Context, scope *parser.Scope, 
 
 func (cg *CodeGen) EmitAliasDecl(ctx context.Context, scope *parser.Scope, alias *parser.AliasDecl, call *parser.CallStmt) (interface{}, error) {
 	var v interface{}
-	_, err := cg.EmitFuncDecl(ctx, scope, alias.Func, call, "", func(aliasCall *parser.CallStmt, aliasValue interface{}) {
+	_, err := cg.EmitFuncDecl(ctx, scope, alias.Func, call, "", func(aliasCall *parser.CallStmt, aliasValue interface{}) bool {
 		if alias.Call == aliasCall {
 			v = aliasValue
+			return false
 		}
+		return true
 	})
 	if err != nil {
 		return nil, err

--- a/compile_test.go
+++ b/compile_test.go
@@ -43,9 +43,9 @@ func TestCompile(t *testing.T) {
 		fs default() {
 			scratch
 			nothing fs { scratch; }
-		  }
+		}
 		fs nothing(fs repo) {
-		  scratch
+			scratch
 		}
 		`,
 		checker.ErrOnlyFirstSource{},
@@ -73,7 +73,7 @@ func TestCompile(t *testing.T) {
 			image "busybox:latest"
 			run "pwd" with option {
 				dir "/etc"
-				myopt 
+				myopt
 			}
 		}
 		`,
@@ -89,6 +89,17 @@ func TestCompile(t *testing.T) {
 		fs bar() {
 			image "busybox:latest"
 			run "echo bar"
+		}
+		`,
+		nil,
+	}, {
+		"cp from alias",
+		[]string{"default"},
+		`
+		fs default() {
+			scratch
+			mkfile "/foo" 0o644 "foo" as this
+			copy this "/foo" "/bar"
 		}
 		`,
 		nil,


### PR DESCRIPTION
fixes #52 

I ended up needing this fixed to work though some testing on #51, so submitting this first.  

Basically I ended up caching the llb.State at the time of the alias definition, then looking that up late rather than attempting to regenerate the llb.State every time the alias is used (causing the infinite recursion when used within the same fs). 

I also removed the aliasCallback, it seemed unnecessary except for the one case where we were trying to lookup to alias results, which I solved by moving the cache into the codegen struct.