### PR TITLE
[#51] remove methods and single-source requirements from fs blocks

### DIFF
--- a/checker/errors.go
+++ b/checker/errors.go
@@ -41,44 +41,12 @@ func (e ErrDuplicateFields) Error() string {
 	return fmt.Sprintf("%s duplicate fields named %s", FormatPos(e.Fields[0].Pos), e.Fields[0].Name)
 }
 
-type ErrNoSource struct {
-	BlockStmt *parser.BlockStmt
-}
-
-func (e ErrNoSource) Error() string {
-	return fmt.Sprintf("%s fs block statement must be non-empty", FormatPos(e.BlockStmt.Pos))
-}
-
-type ErrFirstSource struct {
-	CallStmt *parser.CallStmt
-}
-
-func (e ErrFirstSource) Error() string {
-	return fmt.Sprintf("%s first statement must be source", FormatPos(e.CallStmt.Pos))
-}
-
-type ErrOnlyFirstSource struct {
-	CallStmt *parser.CallStmt
-}
-
-func (e ErrOnlyFirstSource) Error() string {
-	return fmt.Sprintf("%s only first statement must be source", FormatPos(e.CallStmt.Pos))
-}
-
 type ErrInvalidFunc struct {
 	CallStmt *parser.CallStmt
 }
 
 func (e ErrInvalidFunc) Error() string {
 	return fmt.Sprintf("%s invalid func %s", FormatPos(e.CallStmt.Pos), e.CallStmt.Func)
-}
-
-type ErrFuncSource struct {
-	CallStmt *parser.CallStmt
-}
-
-func (e ErrFuncSource) Error() string {
-	return fmt.Sprintf("%s func %s must be used as a fs source", FormatPos(e.CallStmt.Pos), e.CallStmt.Func)
 }
 
 type ErrNumArgs struct {

--- a/compile_test.go
+++ b/compile_test.go
@@ -48,7 +48,7 @@ func TestCompile(t *testing.T) {
 			scratch
 		}
 		`,
-		checker.ErrOnlyFirstSource{},
+		nil,
 	}, {
 		"single named option",
 		[]string{"default"},
@@ -100,6 +100,32 @@ func TestCompile(t *testing.T) {
 			scratch
 			mkfile "/foo" 0o644 "foo" as this
 			copy this "/foo" "/bar"
+		}
+		`,
+		nil,
+	}, {
+		"many sources",
+		[]string{"default"},
+		`
+		fs default() {
+			image "alpine"
+			image "busybox"
+		}
+		`,
+		nil,
+	}, {
+		"compose fs",
+		[]string{"default"},
+		`
+		fs default() {
+			image "alpine" as this
+			myfunc this
+			image "busybox"
+		}
+		fs myfunc(fs base) {
+			base
+			mkfile "/foo" 0o644 "contents"
+			run "echo hi"
 		}
 		`,
 		nil,


### PR DESCRIPTION
fixes #51 

This allows multiple sources to be used within a single fs.  fs "methods" will continue to operate on the previous state in the stack/chain. 