### PR TITLE
Build one flow for codegen to solve using solver.Progress interface, plumb stacktrace to progress UI

### DIFF
--- a/checker/errors.go
+++ b/checker/errors.go
@@ -132,12 +132,3 @@ type ErrBadParse struct {
 func (e ErrBadParse) Error() string {
 	return fmt.Sprintf("%s unable to parse", FormatPos(e.Node.Position()))
 }
-
-type ErrCodeGen struct {
-	Node parser.Node
-	Err  error
-}
-
-func (e ErrCodeGen) Error() string {
-	return fmt.Sprintf("%s %s", FormatPos(e.Node.Position()), e.Err)
-}

--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -154,13 +154,6 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, opts RunOpti
 		return nil
 	}
 
-	// // If codegen encountered an error, then the error was captured by
-	// // solver.Progress so the request will be nil.
-	// if solveReq == nil {
-	// 	p.Release()
-	// 	return p.Wait()
-	// }
-
 	p.Go(func(ctx context.Context) error {
 		defer p.Release()
 		return solveReq.Solve(ctx, cln, p.MultiWriter())

--- a/codegen/debug.go
+++ b/codegen/debug.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/docker/buildx/util/progress"
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/logrusorgru/aurora"
 	"github.com/moby/buildkit/client"
@@ -255,9 +254,11 @@ func NewDebugger(c *client.Client, w io.Writer, r *bufio.Reader, ibs map[string]
 						continue
 					}
 
-					p.WithPrefix("solve", func(ctx context.Context, pw progress.Writer) error {
-						defer p.Release()
+					mw := p.MultiWriter()
+					pw := mw.WithPrefix("solve", false)
 
+					p.Go(func(ctx context.Context) error {
+						defer p.Release()
 						return solver.Solve(ctx, c, pw, st, solver.WithDownloadDockerTarball(ref, wc))
 					})
 

--- a/codegen/errors.go
+++ b/codegen/errors.go
@@ -1,0 +1,21 @@
+package codegen
+
+import (
+	"fmt"
+
+	"github.com/openllb/hlb/checker"
+	"github.com/openllb/hlb/parser"
+)
+
+type ErrCodeGen struct {
+	Node parser.Node
+	Err  error
+}
+
+func (e ErrCodeGen) Error() string {
+	return fmt.Sprintf("%s %s", checker.FormatPos(e.Node.Position()), e.Err)
+}
+
+func (e ErrCodeGen) Cause() error {
+	return e.Err
+}

--- a/compile_test.go
+++ b/compile_test.go
@@ -138,7 +138,6 @@ func TestCompile(t *testing.T) {
 			p, err := solver.NewProgress(ctx, solver.WithLogOutput(solver.LogOutputPlain))
 			require.NoError(t, err)
 
-			mw := p.MultiWriter()
 			in := strings.NewReader(cleanup(tc.input))
 
 			var targets []Target
@@ -146,7 +145,7 @@ func TestCompile(t *testing.T) {
 				targets = append(targets, Target{Name: target})
 			}
 
-			_, err = Compile(ctx, nil, mw, targets, in)
+			_, err = Compile(ctx, nil, p, targets, in)
 			if tc.errType == nil {
 				require.NoError(t, err)
 			} else {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/opencontainers/selinux v1.4.0 // indirect
 	github.com/openllb/doxygen-parser v0.0.0-20200128221307-2aa2d8be1c35
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli/v2 v2.1.1
 	github.com/xlab/treeprint v1.0.0

--- a/solver/progress.go
+++ b/solver/progress.go
@@ -2,9 +2,15 @@ package solver
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/docker/buildx/util/progress"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/identity"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -28,6 +34,18 @@ func WithLogOutput(logOutput LogOutput) ProgressOption {
 		info.LogOutput = logOutput
 		return nil
 	}
+}
+
+type Progress interface {
+	MultiWriter() *progress.MultiWriter
+
+	Write(pfx, name string, fn func(ctx context.Context) error)
+
+	Go(func(ctx context.Context) error)
+
+	Release()
+
+	Wait() error
 }
 
 // NewProgress returns a Progress that presents all the progress on multiple
@@ -69,7 +87,7 @@ func WithLogOutput(logOutput LogOutput) ProgressOption {
 //
 // return p.Wait()
 // ```
-func NewProgress(ctx context.Context, opts ...ProgressOption) (*Progress, error) {
+func NewProgress(ctx context.Context, opts ...ProgressOption) (Progress, error) {
 	info := &ProgressInfo{}
 	for _, opt := range opts {
 		err := opt(info)
@@ -121,27 +139,27 @@ func NewProgress(ctx context.Context, opts ...ProgressOption) (*Progress, error)
 		return nil
 	})
 
-	return &Progress{mw, ctx, g, done}, nil
+	return &progressUI{mw, ctx, g, done}, nil
 }
 
-type Progress struct {
+type progressUI struct {
 	mw   *progress.MultiWriter
 	ctx  context.Context
 	g    *errgroup.Group
 	done chan struct{}
 }
 
-func (p *Progress) MultiWriter() *progress.MultiWriter {
+func (p *progressUI) MultiWriter() *progress.MultiWriter {
 	return p.mw
 }
 
-func (p *Progress) Go(fn func(ctx context.Context) error) {
+func (p *progressUI) Go(fn func(ctx context.Context) error) {
 	p.g.Go(func() error {
 		return fn(p.ctx)
 	})
 }
 
-func (p *Progress) WithPrefix(pfx string, fn func(ctx context.Context, pw progress.Writer) error) {
+func (p *progressUI) Write(pfx, name string, fn func(ctx context.Context) error) {
 	pw := p.mw.WithPrefix(pfx, false)
 	p.g.Go(func() error {
 		<-pw.Done()
@@ -149,14 +167,116 @@ func (p *Progress) WithPrefix(pfx string, fn func(ctx context.Context, pw progre
 	})
 
 	p.g.Go(func() error {
-		return fn(p.ctx, pw)
+		defer close(pw.Status())
+		return write(pw, name, func() error {
+			return fn(p.ctx)
+		})
 	})
 }
 
-func (p *Progress) Release() {
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+func write(pw progress.Writer, name string, fn func() error) error {
+	status := pw.Status()
+	dgst := digest.FromBytes([]byte(identity.NewID()))
+	tm := time.Now()
+
+	vtx := client.Vertex{
+		Digest:  dgst,
+		Name:    name,
+		Started: &tm,
+	}
+
+	status <- &client.SolveStatus{
+		Vertexes: []*client.Vertex{&vtx},
+	}
+
+	err := fn()
+
+	tm2 := time.Now()
+	vtx2 := vtx
+	vtx2.Completed = &tm2
+	if err != nil {
+		vtx2.Error = err.Error()
+	}
+
+	var logs []*client.VertexLog
+	if tracer, ok := errors.Cause(err).(stackTracer); ok {
+		for _, f := range tracer.StackTrace() {
+			logs = append(logs, &client.VertexLog{
+				Vertex:    dgst,
+				Data:      []byte(fmt.Sprintf("%+s:%d\n", f, f)),
+				Timestamp: tm2,
+			})
+		}
+	}
+
+	logs = append(logs, &client.VertexLog{
+		Vertex:    dgst,
+		Data:      []byte(fmt.Sprintf("Caused by: %s", err)),
+		Timestamp: tm2,
+	})
+
+	status <- &client.SolveStatus{
+		Vertexes: []*client.Vertex{&vtx2},
+		Logs:     logs,
+	}
+
+	return nil
+}
+
+func (p *progressUI) Release() {
 	close(p.done)
 }
 
-func (p *Progress) Wait() error {
+func (p *progressUI) Wait() error {
+	return p.g.Wait()
+}
+
+func NewDebugProgress(ctx context.Context) Progress {
+	g, ctx := errgroup.WithContext(ctx)
+
+	done := make(chan struct{})
+	g.Go(func() error {
+		<-done
+		return nil
+	})
+
+	return &debugProgress{
+		ctx:  ctx,
+		g:    g,
+		done: done,
+	}
+}
+
+type debugProgress struct {
+	ctx  context.Context
+	g    *errgroup.Group
+	done chan struct{}
+}
+
+func (p *debugProgress) MultiWriter() *progress.MultiWriter {
+	return nil
+}
+
+func (p *debugProgress) Go(fn func(ctx context.Context) error) {
+	p.g.Go(func() error {
+		return fn(p.ctx)
+	})
+}
+
+func (p *debugProgress) Write(pfx, name string, fn func(ctx context.Context) error) {
+	p.g.Go(func() error {
+		return fn(p.ctx)
+	})
+}
+
+func (p *debugProgress) Release() {
+	close(p.done)
+}
+
+func (p *debugProgress) Wait() error {
 	return p.g.Wait()
 }


### PR DESCRIPTION
Fixes #66 

- Depending on if you're in debug mode or not, we used to split off the flows to deal with a nil `*solver.Progress`. Instead, we move it to an interface and build a `debugProgress` concrete implementation to hide complexity from caller side.
- The progress write in `hlb.Compile` hides the error from codegen because the error is sent to the vertex sent via the solve status channel. Due to how it's implemented in the error contents are not shown in the progress UI but shown in progress plain. We ported it to `func write` that writes to the vertex logs, and also the stack trace if `errors.WithStack` is used.
- There used to be many panics in `codegen` because it should only deal with correct CSTs. However, bugs do happen and we want to make it easy to diagnose the issue. I replaced the errors with a stacktrace as well as a root cause that prints out the source-level line + column.

> Expressions are arguments to functions. Since arguments cannot have arguments of their own, this was just bad logic plumbing arguments down to function exprs and option exprs.
- In #64 we dropped `*parser.CallStmt` when emitting expressions. This is true from a conceptual level but incorrect in `codegen` because we do emit expressions outside of dealing with `*parser.Expr`. This introduced bug #66. We need to revert this change and call it with `nil`, and pass down the `stmt.Call` in the correct contexts.

## Interactive progress

```sh
❯ go run ./cmd/hlb run source.hlb
[+] Building 1.0s (1/1) FINISHED
 => ERROR compiling [default]                                                                                                                                         1.0s
------
 > compiling [default]:
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitFuncDecl
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:19
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitOptionFuncDecl
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:64
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitOptionExpr
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/expr.go:140
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitExecOptions
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:1375
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitOptions
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:866
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitWithOption
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:322
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemChainStmt
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:330
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitChainStmt
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:185
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitBlock
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:157
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemBlock
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:272
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitFuncDecl
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:45
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitAliasDecl
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:81
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemChainStmt
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:833
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitChainStmt
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:185
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitBlock
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:157
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemBlock
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:272
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitFuncDecl
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:45
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemChainStmt
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:823
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitChainStmt
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:185
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitBlock
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:157
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemBlock
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:272
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitFuncDecl
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:45
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemFuncDecl
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:56
#1 1.010 github.com/openllb/hlb/codegen.(*CodeGen).Generate
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:95
#1 1.010 github.com/openllb/hlb.Compile.func1
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/hlb.go:146
#1 1.010 github.com/openllb/hlb/solver.(*progressUI).Write.func2.1
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/solver/progress.go:172
#1 1.010 github.com/openllb/hlb/solver.write
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/solver/progress.go:196
#1 1.010 github.com/openllb/hlb/solver.(*progressUI).Write.func2
#1 1.010 	/home/edgarl/go/src/github.com/openllb/hlb/solver/progress.go:171
#1 1.010 golang.org/x/sync/errgroup.(*Group).Go.func1
#1 1.010 	/home/edgarl/go/pkg/mod/golang.org/x/sync@v0.0.0-20190423024810-112230192c58/errgroup/errgroup.go:57
#1 1.010 runtime.goexit
#1 1.010 	/usr/local/go/src/runtime/asm_amd64.s:1373
#1 1.010 Caused by: go.hlb:32:3: cacheMounts expected args [fs src], found []
```

## Plain progress

```sh
❯ go run ./cmd/hlb run --log-output plain source.hlb
#1 compiling [default]
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitFuncDecl
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:19
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitOptionFuncDecl
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:64
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitOptionExpr
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/expr.go:140
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitExecOptions
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:1375
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitOptions
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:866
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitWithOption
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:322
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemChainStmt
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:330
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitChainStmt
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:185
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitBlock
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:157
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemBlock
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:272
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitFuncDecl
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:45
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitAliasDecl
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:81
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemChainStmt
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:833
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitChainStmt
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:185
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitBlock
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:157
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemBlock
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:272
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitFuncDecl
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:45
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemChainStmt
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:823
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitChainStmt
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:185
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitBlock
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:157
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemBlock
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:272
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitFuncDecl
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:45
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemFuncDecl
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/decl.go:56
#1 1.047 github.com/openllb/hlb/codegen.(*CodeGen).Generate
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/codegen/codegen.go:95
#1 1.047 github.com/openllb/hlb.Compile.func1
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/hlb.go:146
#1 1.047 github.com/openllb/hlb/solver.(*progressUI).Write.func2.1
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/solver/progress.go:172
#1 1.047 github.com/openllb/hlb/solver.write
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/solver/progress.go:196
#1 1.047 github.com/openllb/hlb/solver.(*progressUI).Write.func2
#1 1.047 	/home/edgarl/go/src/github.com/openllb/hlb/solver/progress.go:171
#1 1.047 golang.org/x/sync/errgroup.(*Group).Go.func1
#1 1.047 	/home/edgarl/go/pkg/mod/golang.org/x/sync@v0.0.0-20190423024810-112230192c58/errgroup/errgroup.go:57
#1 1.047 runtime.goexit
#1 1.047 	/usr/local/go/src/runtime/asm_amd64.s:1373
#1 1.047 Caused by: go.hlb:32:3: cacheMounts expected args [fs src], found []
#1 ERROR: go.hlb:32:3: cacheMounts expected args [fs src], found []
------
 > compiling [default]:
#1 1.047 Caused by: go.hlb:32:3: cacheMounts expected args [fs src], found []
------
```