### PR TITLE
Parameterize functions using correct option subtype

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/openllb/hlb/builtin"
 	"github.com/openllb/hlb/parser"
@@ -267,7 +268,7 @@ func (c *checker) checkFieldList(fields []*parser.Field) error {
 func (c *checker) checkBlockStmt(scope *parser.Scope, typ parser.ObjType, block *parser.BlockStmt) error {
 	// Option blocks may be empty and may refer to identifiers or function
 	// literals that don't have a sub-type, so we check them differently.
-	if typ == parser.Option {
+	if strings.HasPrefix(string(typ), string(parser.Option)) {
 		return c.checkOptionBlockStmt(scope, typ, block)
 	}
 

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -240,7 +240,7 @@ func (cg *CodeGen) EmitStringChainStmt(ctx context.Context, scope *parser.Scope,
 		var err error
 		switch n := obj.Node.(type) {
 		case *parser.FuncDecl:
-			v, err = cg.EmitFuncDecl(ctx, scope, n, call, "", noopAliasCallback)
+			v, err = cg.EmitFuncDecl(ctx, scope, n, call, noopAliasCallback)
 		case *parser.AliasDecl:
 			v, err = cg.EmitAliasDecl(ctx, scope, n, call)
 		case *parser.ImportDecl:
@@ -248,7 +248,7 @@ func (cg *CodeGen) EmitStringChainStmt(ctx context.Context, scope *parser.Scope,
 			importObj := importScope.Lookup(call.Func.Selector.Select.Name)
 			switch m := importObj.Node.(type) {
 			case *parser.FuncDecl:
-				v, err = cg.EmitFuncDecl(ctx, scope, m, call, "", noopAliasCallback)
+				v, err = cg.EmitFuncDecl(ctx, scope, m, call, noopAliasCallback)
 			case *parser.AliasDecl:
 				v, err = cg.EmitAliasDecl(ctx, scope, m, call)
 			default:
@@ -820,7 +820,7 @@ func (cg *CodeGen) EmitFilesystemChainStmt(ctx context.Context, scope *parser.Sc
 		var err error
 		switch n := obj.Node.(type) {
 		case *parser.FuncDecl:
-			v, err = cg.EmitFuncDecl(ctx, scope, n, call, "", ac)
+			v, err = cg.EmitFuncDecl(ctx, scope, n, call, ac)
 		case *parser.AliasDecl:
 			v, err = cg.EmitAliasDecl(ctx, scope, n, call)
 		case *parser.ImportDecl:
@@ -828,7 +828,7 @@ func (cg *CodeGen) EmitFilesystemChainStmt(ctx context.Context, scope *parser.Sc
 			importObj := importScope.Lookup(call.Func.Selector.Select.Name)
 			switch m := importObj.Node.(type) {
 			case *parser.FuncDecl:
-				v, err = cg.EmitFuncDecl(ctx, scope, m, call, "", ac)
+				v, err = cg.EmitFuncDecl(ctx, scope, m, call, ac)
 			case *parser.AliasDecl:
 				v, err = cg.EmitAliasDecl(ctx, scope, m, call)
 			default:
@@ -879,7 +879,7 @@ func (cg *CodeGen) EmitOptions(ctx context.Context, scope *parser.Scope, op stri
 	case "copy":
 		return cg.EmitCopyOptions(ctx, scope, op, stmts)
 	default:
-		return nil, errors.Errorf("call stmt does not support options")
+		return nil, errors.Errorf("call stmt does not support options: %s", op)
 	}
 }
 

--- a/codegen/expr.go
+++ b/codegen/expr.go
@@ -137,7 +137,7 @@ func (cg *CodeGen) EmitOptionExpr(ctx context.Context, scope *parser.Scope, call
 		case parser.DeclKind:
 			switch n := obj.Node.(type) {
 			case *parser.FuncDecl:
-				return cg.EmitOptionFuncDecl(ctx, scope, n, call, op)
+				return cg.EmitOptionFuncDecl(ctx, scope, n, call)
 			default:
 				return nil, errors.WithStack(ErrCodeGen{expr, errors.Errorf("unknown option decl kind")})
 			}


### PR DESCRIPTION
Fixes #67 

This is a `codegen` error not a `checker` one so we don't have test framework for this yet unfortunately.

The problem was that I was incorrectly passing in the option subtype when parameterizing the function. It should be based on the function signature's field's type, but for some reason I decided to plumb the `op string` from somewhere. You can see it being `""` most of time, indicating something smelly to begin with.