### PR TITLE
Avoid marshalling the same llb.State in parallel, remove debug exec

### DIFF
--- a/module/resolve.go
+++ b/module/resolve.go
@@ -213,6 +213,11 @@ func (r *remoteResolver) Resolve(ctx context.Context, scope *parser.Scope, decl 
 
 	var ref gateway.Reference
 
+	opts, err := cg.SolveOptions(st)
+	if err != nil {
+		return nil, err
+	}
+
 	g.Go(func() error {
 		return solver.Build(ctx, r.cln, pw, func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 			res, err := c.Solve(ctx, gateway.SolveRequest{
@@ -231,7 +236,7 @@ func (r *remoteResolver) Resolve(ctx context.Context, scope *parser.Scope, decl 
 			<-closed
 
 			return gateway.NewResult(), nil
-		}, cg.SolveOptions()...)
+		}, opts...)
 	})
 
 	<-resolved

--- a/solver/request.go
+++ b/solver/request.go
@@ -49,14 +49,14 @@ func (r *nullRequest) Peer(p Request) Request {
 }
 
 type singleRequest struct {
-	st   llb.State
+	def  *llb.Definition
 	opts []SolveOption
 }
 
 // NewRequest returns a single solve request.
-func NewRequest(st llb.State, opts ...SolveOption) Request {
+func NewRequest(def *llb.Definition, opts ...SolveOption) Request {
 	return &singleRequest{
-		st:   st,
+		def:  def,
 		opts: opts,
 	}
 }
@@ -67,7 +67,7 @@ func (r *singleRequest) Solve(ctx context.Context, cln *client.Client, mw *progr
 		pw = mw.WithPrefix("", false)
 	}
 
-	return Solve(ctx, cln, pw, r.st, r.opts...)
+	return Solve(ctx, cln, pw, r.def, r.opts...)
 }
 
 func (r *singleRequest) Next(n Request) Request {


### PR DESCRIPTION
Fixes #61 

- `(llb.State).Marshal` isn't concurrent safe. We wanted to move `solver.Request` to use `*llb.Definition` instead of `llb.State` because marshalling with constraints should be part of `codegen` at some point.
- Removes `exec` from debugging, we want to use the `Exec` RPC from BuildKit in the future, it's starting to become a maintenance burden when making bigger changes. https://github.com/moby/buildkit/issues/749