### PR TITLE
Asynchronously resolve image configs using gateway and marshal in parallel

### DIFF
--- a/codegen/imageconfig.go
+++ b/codegen/imageconfig.go
@@ -1,0 +1,42 @@
+package codegen
+
+import (
+	"context"
+
+	"github.com/docker/buildx/util/progress"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/client/llb"
+	gateway "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/session"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/openllb/hlb/solver"
+	"golang.org/x/sync/errgroup"
+)
+
+type gatewayResolver struct {
+	cln *client.Client
+	pw  progress.Writer
+	s   *session.Session
+}
+
+func (r *gatewayResolver) ResolveImageConfig(ctx context.Context, ref string, opt llb.ResolveImageConfigOpt) (dgst digest.Digest, cfg []byte, err error) {
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		return r.s.Run(ctx, r.cln.Dialer())
+	})
+
+	g.Go(func() error {
+		return solver.Build(ctx, r.cln, r.s, r.pw, func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+			var err error
+			dgst, cfg, err = c.ResolveImageConfig(ctx, ref, opt)
+			if err != nil {
+				return nil, err
+			}
+
+			return gateway.NewResult(), nil
+		})
+	})
+
+	return dgst, cfg, g.Wait()
+}

--- a/codegen/snapshot.go
+++ b/codegen/snapshot.go
@@ -1,0 +1,157 @@
+package codegen
+
+import (
+	"context"
+	"os"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth/authprovider"
+	"github.com/moby/buildkit/session/filesync"
+	"github.com/moby/buildkit/session/secrets/secretsprovider"
+	"github.com/moby/buildkit/session/sshforward/sshprovider"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/openllb/hlb/solver"
+)
+
+type Snapshot struct {
+	Attachables  []session.Attachable
+	SolveOptions []solver.SolveOption
+}
+
+func (cg *CodeGen) Snapshot(opts ...solver.SolveOption) (*Snapshot, error) {
+	attachables, err := cg.newAttachables()
+	if err != nil {
+		return nil, err
+	}
+
+	solveOpts := make([]solver.SolveOption, len(cg.solveOpts)+len(opts))
+	copy(solveOpts, cg.solveOpts)
+	copy(solveOpts[len(cg.solveOpts):], opts)
+
+	return &Snapshot{
+		Attachables:  attachables,
+		SolveOptions: solveOpts,
+	}, nil
+}
+
+func (cg *CodeGen) buildRequest(ctx context.Context, st llb.State, opts ...solver.SolveOption) (*solver.LazyRequest, error) {
+	snapshot, err := cg.Snapshot(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	lazy := &solver.LazyRequest{}
+
+	cg.g.Go(func() error {
+		var err error
+		lazy.Def, err = st.Marshal(ctx, llb.LinuxAmd64)
+		if err != nil {
+			return err
+		}
+
+		opt, err := withImageSpec(ctx, st)
+		if err != nil {
+			return err
+		}
+
+		lazy.SolveOptions = append(snapshot.SolveOptions, opt)
+		return nil
+	})
+
+	return lazy, nil
+}
+
+func (cg *CodeGen) newSession(ctx context.Context) (*session.Session, error) {
+	s, err := session.NewSession(ctx, "hlb", "")
+	if err != nil {
+		return s, err
+	}
+
+	attachables, err := cg.newAttachables()
+	if err != nil {
+		return s, err
+	}
+
+	for _, a := range attachables {
+		s.Allow(a)
+	}
+
+	return s, nil
+}
+
+func (cg *CodeGen) newAttachables() ([]session.Attachable, error) {
+	// By default, forward docker authentication through the session.
+	attachables := []session.Attachable{authprovider.NewDockerAuthProvider(os.Stderr)}
+
+	// Attach local directory providers to the session.
+	var syncedDirs []filesync.SyncedDir
+	for _, dir := range cg.syncedDirByID {
+		syncedDirs = append(syncedDirs, dir)
+	}
+	if len(syncedDirs) > 0 {
+		attachables = append(attachables, filesync.NewFSSyncProvider(syncedDirs))
+	}
+
+	// Attach ssh forwarding providers to the session.
+	var agentConfigs []sshprovider.AgentConfig
+	for _, cfg := range cg.agentConfigByID {
+		agentConfigs = append(agentConfigs, cfg)
+	}
+	if len(agentConfigs) > 0 {
+		sp, err := sshprovider.NewSSHAgentProvider(agentConfigs)
+		if err != nil {
+			return nil, err
+		}
+		attachables = append(attachables, sp)
+	}
+
+	// Attach secret providers to the session.
+	var fileSources []secretsprovider.FileSource
+	for _, cfg := range cg.fileSourceByID {
+		fileSources = append(fileSources, cfg)
+	}
+	if len(fileSources) > 0 {
+		fileStore, err := secretsprovider.NewFileStore(fileSources)
+		if err != nil {
+			return nil, err
+		}
+		attachables = append(attachables, secretsprovider.NewSecretProvider(fileStore))
+	}
+
+	return attachables, nil
+}
+
+// Reset all the options and session attachables for the next target.
+// If we ever need to parallelize compilation we can revisit this.
+func (cg *CodeGen) reset() {
+	cg.solveOpts = []solver.SolveOption{}
+	cg.syncedDirByID = map[string]filesync.SyncedDir{}
+	cg.fileSourceByID = map[string]secretsprovider.FileSource{}
+	cg.agentConfigByID = map[string]sshprovider.AgentConfig{}
+}
+
+func withImageSpec(ctx context.Context, st llb.State) (solver.SolveOption, error) {
+	env, err := st.Env(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	args, err := st.GetArgs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	dir, err := st.GetDir(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return solver.WithImageSpec(&specs.Image{
+		Config: specs.ImageConfig{
+			Env:        env,
+			Entrypoint: args,
+			WorkingDir: dir,
+		},
+	}), nil
+}

--- a/docs/templates/make.hlb
+++ b/docs/templates/make.hlb
@@ -12,7 +12,7 @@ fs npmInstall(fs manifest) {
 }
 
 fs goBuild(fs context, string package, string binary) {
-	image "golang:1.12-alpine" with option { resolve; }
+	image "golang:1.12-alpine"
 	run "apk add -U git gcc libc-dev"
 	run string {
 		format "go build -o /out/%s -ldflags '-linkmode external -extldflags -static' -a %s" binary package

--- a/go.hlb
+++ b/go.hlb
@@ -22,7 +22,7 @@ fs build(fs src, string package, string verPackage) {
 }
 
 fs crossBuild(fs src, string package, string verPackage) {
-	image "dockercore/golang-cross:1.13.10" with option { resolve; }
+	image "dockercore/golang-cross:1.13.10"
 	env "GOPATH" "/root/go"
 	env "GO111MODULE" "on"
 	dir "/go/src/hlb"

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 
 replace github.com/alecthomas/participle => github.com/hinshun/participle v0.4.2-0.20200115220927-0afe0602c1fc
 
+replace github.com/moby/buildkit => github.com/hinshun/buildkit v0.0.0-20200410232208-8ff11ce5c0e1
+
 replace github.com/hashicorp/go-immutable-radix => github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe
 
 replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/uuid v0.0.0-20160311170451-ebb0a03e909c/go.mod h1:fHzc09UnyJyqyW+bFuq864eh+wC7dj65aXmXLRe5to0=
+github.com/hinshun/buildkit v0.0.0-20200410232208-8ff11ce5c0e1 h1:3Haut/DukPNCIeOyBl19IWztnTq6iZfV9zUV54lHYcM=
+github.com/hinshun/buildkit v0.0.0-20200410232208-8ff11ce5c0e1/go.mod h1:D3DN/Nl4DyMH1LkwpRUJuoghqdigdXd1A6HXt5aZS40=
 github.com/hinshun/participle v0.4.2-0.20200115220927-0afe0602c1fc h1:/IDEdmcUnCJtSDErozACKN9d++/yboRmwCC8DgFQro0=
 github.com/hinshun/participle v0.4.2-0.20200115220927-0afe0602c1fc/go.mod h1:T8u4bQOSMwrkTWOSyt8/jSFPEnRtd0FKFMjVfYBlqPs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -283,9 +285,6 @@ github.com/mitchellh/hashstructure v0.0.0-20170609045927-2bca23e0e452/go.mod h1:
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
-github.com/moby/buildkit v0.7.0/go.mod h1:zOhLO1TiQepuSfzoNDQ542IGJQy0CHr79T4MOJvaewY=
-github.com/moby/buildkit v0.7.1-0.20200409032528-226a5db9ad3d h1:enoJGnje9YxuvZcF7UJmWlkDH2ABMUCfGHwnx+pcT2o=
-github.com/moby/buildkit v0.7.1-0.20200409032528-226a5db9ad3d/go.mod h1:D3DN/Nl4DyMH1LkwpRUJuoghqdigdXd1A6HXt5aZS40=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -405,7 +404,6 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/theupdateframework/notary v0.6.1 h1:7wshjstgS9x9F5LuB1L5mBI2xNMObWqjz+cjWoom6l0=
 github.com/theupdateframework/notary v0.6.1/go.mod h1:MOfgIfmox8s7/7fduvB2xyPPMJCrjRLRizA8OFwpnKY=
-github.com/tonistiigi/fsutil v0.0.0-20200225063759-013a9fe6aee2/go.mod h1:0G1sLZ/0ttFf09xvh7GR4AEECnjifHRNJN/sYbLianU=
 github.com/tonistiigi/fsutil v0.0.0-20200326231323-c2c7d7b0e144 h1:6RY1EKxCnPQShPM46xFDHta2JSOd+YKCgHyyBHtKuo8=
 github.com/tonistiigi/fsutil v0.0.0-20200326231323-c2c7d7b0e144/go.mod h1:0G1sLZ/0ttFf09xvh7GR4AEECnjifHRNJN/sYbLianU=
 github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe/go.mod h1:/+MCh11CJf2oz0BXmlmqyopK/ad1rKkcOXPoYuPCJYU=

--- a/solver/request.go
+++ b/solver/request.go
@@ -49,18 +49,21 @@ func (r *nullRequest) Peer(p Request) Request {
 	return p
 }
 
+type LazyRequest struct {
+	Def       *llb.Definition
+	SolveOptions []SolveOption
+}
+
 type singleRequest struct {
 	s    *session.Session
-	def  *llb.Definition
-	opts []SolveOption
+	lazy *LazyRequest
 }
 
 // NewRequest returns a single solve request.
-func NewRequest(s *session.Session, def *llb.Definition, opts ...SolveOption) Request {
+func NewRequest(s *session.Session, lazy *LazyRequest) Request {
 	return &singleRequest{
 		s:    s,
-		def:  def,
-		opts: opts,
+		lazy: lazy,
 	}
 }
 
@@ -77,7 +80,7 @@ func (r *singleRequest) Solve(ctx context.Context, cln *client.Client, mw *progr
 	})
 
 	g.Go(func() error {
-		return Solve(ctx, cln, r.s, pw, r.def, r.opts...)
+		return Solve(ctx, cln, r.s, pw, r.lazy.Def, r.lazy.SolveOptions...)
 	})
 
 	return g.Wait()


### PR DESCRIPTION
- Moves marshalling/validation/get state metadata into goroutines to execute concurrently

```sh
$ hlb run -t foo -t bar -t baz source.hlb
[+] Building 0.9s (9/9) FINISHED
 => compiling [foo bar baz]                                                                                                                                           0.8s
 => resolve image config for docker.io/library/golang:alpine                                                                                                          0.5s
 => resolve image config for docker.io/library/busybox:latest                                                                                                         0.4s
 => resolve image config for docker.io/library/alpine:latest                                                                                                          0.6s
 => resolve image config for docker.io/library/node:alpine                                                                                                            0.6s
```

## TODO
- [ ] Still appears to be a panic from BuildKit `llb`. There are more unprotected maps there. We can either contribute more PRs upstream or think of how to deep copy `llb.State`.