### PR TITLE
Add codegen test framework

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -1849,6 +1849,10 @@ func (cg *CodeGen) LocalID(path string, opts ...llb.LocalOption) (string, error)
 		return "", err
 	}
 
+	// The terminal op of the graph def.Def[len(def.Def)-1] is an empty vertex with
+	// an input to the last vertex's digest. Since that vertex also has its digests
+	// of its inputs and so on, the digest of the terminal op is a merkle hash for
+	// the graph.
 	return digest.FromBytes(def.Def[len(def.Def)-1]).String(), nil
 }
 

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -1,0 +1,159 @@
+package codegen
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/openllb/hlb/checker"
+	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/solver"
+	"github.com/stretchr/testify/require"
+	"github.com/xlab/treeprint"
+)
+
+func Expect(st llb.State) solver.Request {
+	def, err := st.Marshal(context.Background(), llb.LinuxAmd64)
+	if err != nil {
+		panic(err)
+	}
+
+	return solver.Single(&solver.Params{
+		Def: def,
+	})
+}
+
+type testCase struct {
+	name    string
+	targets []string
+	input   string
+	fn      func(cg *CodeGen) (solver.Request, error)
+}
+
+func cleanup(value string) string {
+	result := strings.TrimSpace(value)
+	result = strings.ReplaceAll(result, strings.Repeat("\t", 3), "")
+	result = strings.ReplaceAll(result, "|\n", "| \n")
+	return result
+}
+
+func TestCodeGen(t *testing.T) {
+	for _, tc := range []testCase{{
+		"image",
+		[]string{"default"},
+		`
+		fs default() {
+			image "alpine"
+		}
+		`,
+		func(cg *CodeGen) (solver.Request, error) {
+			return solver.Parallel(
+				Expect(llb.Image("alpine")),
+			), nil
+		},
+	}, {
+		"call function",
+		[]string{"default"},
+		`
+		fs default() {
+			foo "busybox"
+		}
+
+		fs foo(string ref) {
+			image ref
+		}
+		`,
+		func(cg *CodeGen) (solver.Request, error) {
+			return solver.Parallel(
+				Expect(llb.Image("busybox")),
+			), nil
+		},
+	}, {
+		"local",
+		[]string{"default"},
+		`
+		fs default() {
+			local "."
+		}
+		`,
+		func(cg *CodeGen) (solver.Request, error) {
+			id, err := cg.LocalID(".")
+			if err != nil {
+				return nil, err
+			}
+
+			return solver.Parallel(
+				Expect(llb.Local(id, llb.SessionID(cg.SessionID()))),
+			), nil
+		},
+		// }, {
+		// 	"sequential group",
+		// 	[]string{"default"},
+		// 	`
+		// 	group default() {
+		// 		image "alpine"
+		// 		image "busybox"
+		// 	}
+		// 	`,
+		// 	func(cg *CodeGen) (solver.Request, error) {
+		// 		return solver.Sequential(
+		// 			Expect(llb.Image("alpine")),
+		// 			Expect(llb.Image("busybox")),
+		// 		), nil
+		// 	},
+		// }, {
+		// 	"parallel group",
+		// 	[]string{"default"},
+		// 	`
+		// 	group default() {
+		// 		parallel group {
+		// 			image "alpine"
+		// 		} group {
+		// 			image "busybox"
+		// 		}
+		// 	}
+		// 	`,
+		// 	func(cg *CodeGen) (solver.Request, error) {
+		// 		return solver.Parallel(
+		// 			Expect(llb.Image("alpine")),
+		// 			Expect(llb.Image("busybox")),
+		// 		), nil
+		// 	},
+	}} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cg, err := New()
+			require.NoError(t, err)
+
+			mod, err := parser.Parse(strings.NewReader(cleanup(tc.input)))
+			require.NoError(t, err)
+
+			err = checker.Check(mod)
+			require.NoError(t, err)
+
+			var targets []Target
+			for _, target := range tc.targets {
+				targets = append(targets, Target{Name: target})
+			}
+
+			request, err := cg.Generate(context.Background(), mod, targets)
+			require.NoError(t, err)
+
+			testRequest, err := tc.fn(cg)
+			require.NoError(t, err)
+
+			expected := treeprint.New()
+			testRequest.Tree(expected)
+
+			actual := treeprint.New()
+			request.Tree(actual)
+			t.Log(actual.String())
+
+			// Compare trees.
+			require.Equal(t, expected.String(), actual.String())
+		})
+	}
+}

--- a/solver/solve.go
+++ b/solver/solve.go
@@ -22,7 +22,7 @@ type SolveInfo struct {
 	OutputLocal           string
 	OutputLocalTarball    bool
 	OutputLocalOCITarball bool
-	Callbacks             []func() error
+	Callbacks             []func() error `json:"-"`
 	ImageSpec             *specs.Image
 }
 


### PR DESCRIPTION
- Simplified how `llb.Local` id is calculated. The terminal op of the graph `def.Def[len(def.Def)-1]` is an empty vertex with an input to the last vertex's digest. Since that vertex also has its digests of its inputs and so on, the digest of the terminal op is a merkle hash for the graph.
- Change `solver/request` to be more testable
- Add `(solver.Request).Tree` to debug solve trees and compare results with expected value

```sh
❯ go test -v ./codegen
=== RUN   TestCodeGen
=== RUN   TestCodeGen/image
=== PAUSE TestCodeGen/image
=== RUN   TestCodeGen/call_function
=== PAUSE TestCodeGen/call_function
=== RUN   TestCodeGen/local
=== PAUSE TestCodeGen/local
=== CONT  TestCodeGen/image
=== CONT  TestCodeGen/local
=== CONT  TestCodeGen/call_function
--- PASS: TestCodeGen (0.00s)
    --- PASS: TestCodeGen/image (0.00s)
        codegen_test.go:153: .
            └── parallel
                └── single
                    └── [source]  identifier:"docker-image://docker.io/library/alpine:latest"

    --- PASS: TestCodeGen/local (0.00s)
        codegen_test.go:153: .
            └── parallel
                └── single
                    └── [source]  identifier:"local://sha256:9c47e3158363ec87074ac17b48adf8db980ffdc680a347d3106c9d8dc1ddebc5" attrs:<key:"local.session" value:"661ubccj9uggraywqw5imxova" >

    --- PASS: TestCodeGen/call_function (0.00s)
        codegen_test.go:153: .
            └── parallel
                └── single
                    └── [source]  identifier:"docker-image://docker.io/library/busybox:latest"

PASS
ok  	github.com/openllb/hlb/codegen	(cached)
```