### PR TITLE
update tree output for exec to make more readable

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -575,7 +575,9 @@ func (cg *CodeGen) EmitFilesystemChainStmt(ctx context.Context, scope *parser.Sc
 		if err != nil {
 			return so, err
 		}
-		opts = append(opts, llb.SessionID(cg.sessionID))
+		opts = append(opts, llb.SessionID(cg.sessionID), llb.WithDescription(map[string]string{
+			solver.LocalPathDescriptionKey: fmt.Sprintf("local://%s", path),
+		}))
 
 		// Register paths as syncable directories for the session.
 		cg.syncedDirByID[id] = filesync.SyncedDir{


### PR DESCRIPTION
Current output:
```
hlb run --tree ./source.hlb
[+] Building 1.6s (1/1) FINISHED
 => compiling [default]                                                                                                                                                                                        1.6s
.
└── parallel
    └── parallel
        ├── single
        │   └── [exec]  meta:<args:"/bin/sh" args:"-c" args:"v=$(git describe --match 'v[0-9]*' --tags --dirty='.dirty' --always | sed 's/^v//') && LDFLAGS=\"-X github.com/openllb/hlb.Version=$v\" /cross/build \"github.com/openllb/hlb/cmd/hlb\"" env:"PATH=/osxcross/target/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" env:"GOLANG_VERSION=1.13.10" env:"OSX_CROSS_PATH=/osxcross" env:"GOPATH=/root/go" env:"GO111MODULE=on" cwd:"/go/src/hlb" > mounts:<dest:"/" > mounts:<input:1 selector:"/scripts" dest:"/cross" output:-1 readonly:true > mounts:<input:-1 dest:"/go/pkg/mod" output:-1 mountType:CACHE cacheOpt:<ID:"hlb/go-mod" sharing:PRIVATE > > mounts:<input:2 dest:"/go/src/hlb" output:-1 readonly:true > mounts:<input:-1 dest:"/root/.cache/go-build" output:-1 mountType:CACHE cacheOpt:<ID:"hlb/go-build" sharing:PRIVATE > > mounts:<input:-1 dest:"/root/go/bin" output:1 >
        │       ├── [source]  identifier:"docker-image://docker.io/dockercore/golang-cross:1.13.10"
        │       ├── [source]  identifier:"git://github.com/hinshun/go-cross.git" attrs:<key:"git.fullurl" value:"https://github.com/hinshun/go-cross.git" >
        │       └── [source]  identifier:"local://sha256:b5a53a856aa2c608a534f9fa01fd455bacbcabd94d21021d225e0d51ba854a3d" attrs:<key:"local.excludepatterns" value:"[\"build\"]" > attrs:<key:"local.session" value:"hynv9j9mpslyliafpsgc9sec4" >
        └── single
            └── [exec]  meta:<args:"/bin/sh" args:"-c" args:"v=$(git describe --match 'v[0-9]*' --tags --dirty='.dirty' --always | sed 's/^v//') && LDFLAGS=\"-X github.com/openllb/hlb.Version=$v\" /cross/build \"github.com/openllb/hlb/cmd/hlb\"" env:"PATH=/osxcross/target/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" env:"GOLANG_VERSION=1.13.10" env:"OSX_CROSS_PATH=/osxcross" env:"GOPATH=/root/go" env:"GO111MODULE=on" cwd:"/go/src/hlb" > mounts:<dest:"/" > mounts:<input:1 selector:"/scripts" dest:"/cross" output:-1 readonly:true > mounts:<input:-1 dest:"/go/pkg/mod" output:-1 mountType:CACHE cacheOpt:<ID:"hlb/go-mod" sharing:PRIVATE > > mounts:<input:2 dest:"/go/src/hlb" output:-1 readonly:true > mounts:<input:-1 dest:"/root/.cache/go-build" output:-1 mountType:CACHE cacheOpt:<ID:"hlb/go-build" sharing:PRIVATE > > mounts:<input:-1 dest:"/root/go/bin" output:1 >
                ├── [source]  identifier:"docker-image://docker.io/dockercore/golang-cross:1.13.10"
                ├── [source]  identifier:"git://github.com/hinshun/go-cross.git" attrs:<key:"git.fullurl" value:"https://github.com/hinshun/go-cross.git" >
                └── [source]  identifier:"local://sha256:b5a53a856aa2c608a534f9fa01fd455bacbcabd94d21021d225e0d51ba854a3d" attrs:<key:"local.excludepatterns" value:"[\"build\"]" > attrs:<key:"local.session" value:"hynv9j9mpslyliafpsgc9sec4" >
```

Output with PR:
```
./hlb run --tree ./source.hlb
[+] Building 1.7s (1/1) FINISHED
 => compiling [default]                                                                                                                                                                                        1.7s
.
└── parallel
    └── parallel
        ├── single
        │   └── [exec]  v=$(git describe --match 'v[0-9]*' --tags --dirty='.dirty' --always | sed 's/^v//') && LDFLAGS="-X github.com/openllb/hlb.Version=$v" /cross/build "github.com/openllb/hlb/cmd/hlb"
        │       ├── [env]  PATH=/osxcross/target/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
        │       ├── [env]  GOLANG_VERSION=1.13.10
        │       ├── [env]  OSX_CROSS_PATH=/osxcross
        │       ├── [env]  GOPATH=/root/go
        │       ├── [env]  GO111MODULE=on
        │       ├── [cwd]  /go/src/hlb
        │       ├── [mount]  docker-image://docker.io/dockercore/golang-cross:1.13.10 => / [type=BIND]
        │       ├── [mount]  git://github.com/hinshun/go-cross.git/scripts => /cross [type=BIND,ro]
        │       ├── [mount]  scratch => /go/pkg/mod [type=CACHE,cache-id=hlb/go-mod,sharing=PRIVATE]
        │       ├── [mount]  local://sha256:4e682aa48bfe4517ae4f1372a4c72944a5d1bc6c8bf2466ac9cac4fc3c13a63b => /go/src/hlb [type=BIND,ro]
        │       ├── [mount]  scratch => /root/.cache/go-build [type=CACHE,cache-id=hlb/go-build,sharing=PRIVATE]
        │       └── [mount]  scratch => /root/go/bin [type=BIND]
        └── single
            └── [exec]  v=$(git describe --match 'v[0-9]*' --tags --dirty='.dirty' --always | sed 's/^v//') && LDFLAGS="-X github.com/openllb/hlb.Version=$v" /cross/build "github.com/openllb/hlb/cmd/hlb"
                ├── [env]  PATH=/osxcross/target/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
                ├── [env]  GOLANG_VERSION=1.13.10
                ├── [env]  OSX_CROSS_PATH=/osxcross
                ├── [env]  GOPATH=/root/go
                ├── [env]  GO111MODULE=on
                ├── [cwd]  /go/src/hlb
                ├── [mount]  docker-image://docker.io/dockercore/golang-cross:1.13.10 => / [type=BIND]
                ├── [mount]  git://github.com/hinshun/go-cross.git/scripts => /cross [type=BIND,ro]
                ├── [mount]  scratch => /go/pkg/mod [type=CACHE,cache-id=hlb/go-mod,sharing=PRIVATE]
                ├── [mount]  local://sha256:4e682aa48bfe4517ae4f1372a4c72944a5d1bc6c8bf2466ac9cac4fc3c13a63b => /go/src/hlb [type=BIND,ro]
                ├── [mount]  scratch => /root/.cache/go-build [type=CACHE,cache-id=hlb/go-build,sharing=PRIVATE]
                └── [mount]  scratch => /root/go/bin [type=BIND]
```

Note the `[source]` lines are merged with the corresponding `[mount]` lines. 

btw, there does seem to be a subtle bug in our graph generation, not sure why we are duping the same `single` twice, but will try to fix that in seperate PR.