### PR TITLE
Implement sequential and parallel groups

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -134,6 +134,15 @@ var (
 					},
 				},
 			},
+			"group": LookupByType{
+				Func: map[string]FuncLookup{
+					"parallel": FuncLookup{
+						Params: []*parser.Field{
+							parser.NewField("group", "groups", true),
+						},
+					},
+				},
+			},
 			"option::copy": LookupByType{
 				Func: map[string]FuncLookup{
 					"followSymlinks": FuncLookup{

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -319,7 +319,12 @@ func (c *checker) checkBlockStmt(scope *parser.Scope, typ parser.ObjType, block 
 		// If the function is not a builtin, retrieve it from the scope and then
 		// type check it.
 		_, ok := builtin.Lookup.ByType[typ].Func[name]
+		if !ok && typ == parser.Group {
+			_, ok = builtin.Lookup.ByType[parser.Filesystem].Func[name]
+		}
+
 		if !ok {
+
 			obj := scope.Lookup(name)
 			if obj == nil {
 				return ErrIdentNotDefined{Ident: call.Func.Ident}
@@ -378,6 +383,10 @@ func (c *checker) checkCallSignature(scope *parser.Scope, typ parser.ObjType, ca
 
 	var signature []*parser.Field
 	fun, ok := builtin.Lookup.ByType[typ].Func[ident.Name]
+	if !ok && typ == parser.Group {
+		fun, ok = builtin.Lookup.ByType[parser.Filesystem].Func[ident.Name]
+	}
+
 	if ok {
 		signature = fun.Params
 	} else {

--- a/codegen/decl.go
+++ b/codegen/decl.go
@@ -6,6 +6,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/openllb/hlb/checker"
 	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/solver"
 	"github.com/pkg/errors"
 )
 
@@ -55,6 +56,8 @@ func (cg *CodeGen) EmitFuncDecl(ctx context.Context, scope *parser.Scope, fun *p
 		return cg.EmitOptions(ctx, fun.Scope, string(fun.Type.Secondary()), fun.Body.NonEmptyStmts(), ac)
 	case parser.Str:
 		return cg.EmitStringBlock(ctx, fun.Scope, fun.Body.NonEmptyStmts(), v)
+	case parser.Group:
+		return cg.EmitGroupBlock(ctx, fun.Scope, fun.Body.NonEmptyStmts(), ac, v)
 	default:
 		return v, checker.ErrInvalidTarget{Node: fun}
 	}
@@ -79,6 +82,34 @@ func (cg *CodeGen) EmitStringFuncDecl(ctx context.Context, scope *parser.Scope, 
 		return "", err
 	}
 	return v.(string), err
+}
+
+func (cg *CodeGen) EmitGroupFuncDecl(ctx context.Context, scope *parser.Scope, fun *parser.FuncDecl, call *parser.CallStmt, ac aliasCallback, chainStart interface{}) (solver.Request, error) {
+	v, err := cg.EmitFuncDecl(ctx, scope, fun, call, ac, chainStart)
+	if v == nil {
+		return nil, err
+	}
+
+	var request solver.Request
+	switch t := v.(type) {
+	case solver.Request:
+		request = t
+	case llb.State:
+		request, err = cg.outputRequest(ctx, t, Output{})
+		if err != nil {
+			return request, err
+		}
+
+		if len(cg.requests) > 0 {
+			request = solver.Parallel(append([]solver.Request{request}, cg.requests...)...)
+		}
+
+		cg.reset()
+	default:
+		return request, errors.WithStack(ErrCodeGen{fun, errors.Errorf("unknown group func decl")})
+	}
+
+	return request, err
 }
 
 func (cg *CodeGen) EmitAliasDecl(ctx context.Context, scope *parser.Scope, alias *parser.AliasDecl, call *parser.CallStmt, chainStart interface{}) (interface{}, error) {
@@ -110,6 +141,14 @@ func (cg *CodeGen) EmitStringAliasDecl(ctx context.Context, scope *parser.Scope,
 		return "", err
 	}
 	return v.(string), err
+}
+
+func (cg *CodeGen) EmitGroupAliasDecl(ctx context.Context, scope *parser.Scope, alias *parser.AliasDecl, call *parser.CallStmt, chainStart interface{}) (solver.Request, error) {
+	v, err := cg.EmitAliasDecl(ctx, scope, alias, call, chainStart)
+	if v == nil {
+		return nil, err
+	}
+	return v.(solver.Request), err
 }
 
 func (cg *CodeGen) ParameterizedScope(ctx context.Context, scope *parser.Scope, call *parser.CallStmt, fun *parser.FuncDecl, args []*parser.Expr, ac aliasCallback, chainStart interface{}) error {
@@ -151,6 +190,10 @@ func (cg *CodeGen) ParameterizedScope(ctx context.Context, scope *parser.Scope, 
 			} else {
 				v, err = cg.EmitOptionExpr(ctx, scope, nil, string(field.Type.Secondary()), args[i])
 			}
+			data = v
+		case parser.Group:
+			var v solver.Request
+			v, err = cg.EmitGroupExpr(ctx, scope, nil, args[i], ac, chainStart)
 			data = v
 		}
 		if err != nil {

--- a/language/builtin.hlb
+++ b/language/builtin.hlb
@@ -493,3 +493,9 @@ fs downloadDockerTarball(string localPath, string ref)
 # specifier.
 # @return the resulting string from formatting.
 string format(string formatString, variadic string values)
+
+# Execute groups in parallel.
+#
+# @param groups the groups to run in parallel
+# @return a group that finishes when all of its groups are finished.
+group parallel(variadic group groups)

--- a/parser/cst.go
+++ b/parser/cst.go
@@ -17,7 +17,7 @@ var (
 
 		Keyword  = \b(with|as|import|export|from)\b
 		Modifier = \b(variadic)\b
-		Type     = \b(string|int|bool|fs|option)(::[a-z][a-z]*)?\b
+		Type     = \b(string|int|bool|fs|option|group)(::[a-z][a-z]*)?\b
 		Numeric  = \b(0(b|B|o|O|x|X)[a-fA-F0-9]+)\b
 		Decimal  = \b(0|[1-9][0-9]*)\b
 		String   = "(\\.|[^"])*"|'[^']*'
@@ -335,6 +335,9 @@ func (t *Type) Equals(typ ObjType) bool {
 		parts := typeParts(typ)
 		return ObjType(parts[0]) == Option
 	}
+	if typ == Group {
+		return t.ObjType == Filesystem || t.ObjType == Group
+	}
 	return t.ObjType == typ
 }
 
@@ -347,6 +350,7 @@ const (
 	Bool       ObjType = "bool"
 	Filesystem ObjType = "fs"
 	Option     ObjType = "option"
+	Group      ObjType = "group"
 )
 
 // Ident represents an identifier.


### PR DESCRIPTION
Fixes #47 

- Group statements are sequential, there is a builtin `parallel` that accepts variadic groups to execute them in parallel
- `fs` can be coerced to `group` but `group` cannot be coerced to `fs`

## TODO
- [x] Add tests

## Example

```hlb
group foo() {
	createFoo "hello"
	appendFoo " world"
}

fs createFoo(string msg) {
	scratch
	mkfile "foo" 0o644 msg
	download "."
}

fs appendFoo(string msg) {
	scratch
	copy fs { busyboxAppendFoo msg; } "/foo" "/"
	download "."
}

fs busyboxAppendFoo(string msg) {
	image "busybox"
	copy fs {
		local "." with option { includePatterns "foo"; }
	} "foo" "/foo"
	run string {
		format "echo \"%s\" >> /foo" msg
	}
}
```

```sh
$ hlb run -t foo source.hlb
[+] Building 1.2s (8/8) FINISHED
 => compiling [foo]                                                                                                                                                   0.0s
 => CACHED mkfile /foo                                                                                                                                                0.0s
 => exporting to client                                                                                                                                               0.0s
 => => copying files 38B                                                                                                                                              0.0s
 => docker-image://docker.io/library/busybox:latest                                                                                                                   0.4s
 => => resolve docker.io/library/busybox:latest                                                                                                                       0.4s
 => local://sha256:06095942018ca3c76704f24839313e5f0bd6bae66ebe024f3b6d331d23e508c7 (foo)                                                                             0.0s
 => => transferring sha256:06095942018ca3c76704f24839313e5f0bd6bae66ebe024f3b6d331d23e508c7: 35B                                                                      0.0s
 => CACHED copy /foo /foo                                                                                                                                             0.0s
 => /bin/sh -c echo " world" >> /foo                                                                                                                                  0.4s
 => copy /foo /                                                                                                                                                       0.1s

$ cat foo
hello world
```