### PR TITLE
Add localEnv string builtin

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -424,6 +424,11 @@ var (
 							parser.NewField(parser.Str, "values", true),
 						},
 					},
+					"localEnv": FuncLookup{
+						Params: []*parser.Field{
+							parser.NewField(parser.Str, "key", false),
+						},
+					},
 				},
 			},
 		},

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -414,6 +414,15 @@ func (cg *CodeGen) EmitStringChainStmt(ctx context.Context, scope *parser.Scope,
 		return func(_ string) (string, error) {
 			return fmt.Sprintf(formatStr, as...), nil
 		}, nil
+	case "localEnv":
+		key, err := cg.EmitStringExpr(ctx, scope, call, args[0])
+		if err != nil {
+			return nil, err
+		}
+
+		return func(_ string) (string, error) {
+			return os.Getenv(key), nil
+		}, nil
 	default:
 		// Must be a named reference.
 		obj := scope.Lookup(name)

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -2,6 +2,7 @@ package codegen
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -76,6 +77,22 @@ func TestCodeGen(t *testing.T) {
 			require.NoError(t, err)
 
 			return Expect(t, llb.Local(id, llb.SessionID(cg.SessionID())))
+		},
+	}, {
+		"local env",
+		[]string{"default"},
+		`
+		fs default() {
+			scratch
+			mkfile "home" 0o644 foo
+		}
+
+		string foo() {
+			localEnv "HOME"
+		}
+		`,
+		func(t *testing.T, cg *CodeGen) solver.Request {
+			return Expect(t, llb.Scratch().File(llb.Mkfile("home", 0644, []byte(os.Getenv("HOME")))))
 		},
 	}, {
 		"empty group",

--- a/language/builtin.hlb
+++ b/language/builtin.hlb
@@ -494,6 +494,12 @@ fs downloadDockerTarball(string localPath, string ref)
 # @return the resulting string from formatting.
 string format(string formatString, variadic string values)
 
+# An environment variable from the client's local environment.
+#
+# @param the environment variable's key.
+# @return the environment variable's value
+string localEnv(string key)
+
 # Execute groups in parallel.
 #
 # @param groups the groups to run in parallel


### PR DESCRIPTION
See test for example.

I chose `localEnv` to distinguish it from the `env` instruction for `fs`. Perhaps `getEnv` is better? WDYT?