### PR TITLE
Resolve paths relative to the module's filepath

### DIFF
--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -167,7 +167,11 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		if err != nil {
 			return fc, err
 		}
-		path = ResolvePathForNode(scope.Node, path)
+
+		path, err = ResolvePathForNode(scope.Node, path)
+		if err != nil {
+			return fc, err
+		}
 
 		var opts []llb.LocalOption
 		for _, iopt := range iopts {
@@ -497,7 +501,11 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		if err != nil {
 			return fc, err
 		}
-		localPath = ResolvePathForNode(scope.Node, localPath)
+
+		localPath, err = ResolvePathForNode(scope.Node, localPath)
+		if err != nil {
+			return fc, err
+		}
 
 		fc = func(st llb.State) (llb.State, error) {
 			request, err := cg.outputRequest(ctx, st, Output{Type: OutputDownload, LocalPath: localPath})
@@ -512,7 +520,11 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		if err != nil {
 			return fc, err
 		}
-		localPath = ResolvePathForNode(scope.Node, localPath)
+
+		localPath, err = ResolvePathForNode(scope.Node, localPath)
+		if err != nil {
+			return fc, err
+		}
 
 		fc = func(st llb.State) (llb.State, error) {
 			request, err := cg.outputRequest(ctx, st, Output{Type: OutputDownloadTarball, LocalPath: localPath})
@@ -527,7 +539,11 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		if err != nil {
 			return fc, err
 		}
-		localPath = ResolvePathForNode(scope.Node, localPath)
+
+		localPath, err = ResolvePathForNode(scope.Node, localPath)
+		if err != nil {
+			return fc, err
+		}
 
 		fc = func(st llb.State) (llb.State, error) {
 			request, err := cg.outputRequest(ctx, st, Output{Type: OutputDownloadOCITarball, LocalPath: localPath})
@@ -542,7 +558,11 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		if err != nil {
 			return fc, err
 		}
-		localPath = ResolvePathForNode(scope.Node, localPath)
+
+		localPath, err = ResolvePathForNode(scope.Node, localPath)
+		if err != nil {
+			return fc, err
+		}
 
 		ref, err := cg.EmitStringExpr(ctx, scope, args[1])
 		if err != nil {

--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -167,6 +167,7 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		if err != nil {
 			return fc, err
 		}
+		path = ResolvePathForNode(scope.Node, path)
 
 		var opts []llb.LocalOption
 		for _, iopt := range iopts {
@@ -178,7 +179,7 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		if err != nil {
 			return fc, err
 		}
-		opts = append(opts, llb.SessionID(cg.sessionID), llb.WithDescription(map[string]string{
+		opts = append(opts, llb.SessionID(cg.sessionID), llb.SharedKeyHint(path), llb.WithDescription(map[string]string{
 			solver.LocalPathDescriptionKey: fmt.Sprintf("local://%s", path),
 		}))
 
@@ -482,6 +483,7 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		if err != nil {
 			return fc, err
 		}
+
 		fc = func(st llb.State) (llb.State, error) {
 			request, err := cg.outputRequest(ctx, st, Output{Type: OutputDockerLoad, Ref: ref})
 			if err != nil {
@@ -495,6 +497,7 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		if err != nil {
 			return fc, err
 		}
+		localPath = ResolvePathForNode(scope.Node, localPath)
 
 		fc = func(st llb.State) (llb.State, error) {
 			request, err := cg.outputRequest(ctx, st, Output{Type: OutputDownload, LocalPath: localPath})
@@ -509,6 +512,7 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		if err != nil {
 			return fc, err
 		}
+		localPath = ResolvePathForNode(scope.Node, localPath)
 
 		fc = func(st llb.State) (llb.State, error) {
 			request, err := cg.outputRequest(ctx, st, Output{Type: OutputDownloadTarball, LocalPath: localPath})
@@ -523,6 +527,7 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		if err != nil {
 			return fc, err
 		}
+		localPath = ResolvePathForNode(scope.Node, localPath)
 
 		fc = func(st llb.State) (llb.State, error) {
 			request, err := cg.outputRequest(ctx, st, Output{Type: OutputDownloadOCITarball, LocalPath: localPath})
@@ -537,6 +542,7 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		if err != nil {
 			return fc, err
 		}
+		localPath = ResolvePathForNode(scope.Node, localPath)
 
 		ref, err := cg.EmitStringExpr(ctx, scope, args[1])
 		if err != nil {

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/llb/imagemetaresolver"
@@ -959,7 +960,11 @@ func (cg *CodeGen) EmitExecOptions(ctx context.Context, scope *parser.Scope, op 
 				)
 				switch srcUri.Scheme {
 				case "unix":
-					path = ResolvePathForNode(scope.Node, srcUri.Path)
+					path, err = ResolvePathForNode(scope.Node, srcUri.Path)
+					if err != nil {
+						return opts, err
+					}
+
 					id = digest.FromString(path).String()
 				default:
 					conn, err := net.Dial(srcUri.Scheme, srcUri.Host)
@@ -1020,7 +1025,11 @@ func (cg *CodeGen) EmitExecOptions(ctx context.Context, scope *parser.Scope, op 
 				if err != nil {
 					return opts, err
 				}
-				localPath = ResolvePathForNode(scope.Node, localPath)
+
+				localPath, err = ResolvePathForNode(scope.Node, localPath)
+				if err != nil {
+					return opts, err
+				}
 
 				mountPoint, err := cg.EmitStringExpr(ctx, scope, args[1])
 				if err != nil {
@@ -1131,7 +1140,13 @@ func (cg *CodeGen) EmitSSHOptions(ctx context.Context, scope *parser.Scope, op s
 					if err != nil {
 						return opts, err
 					}
-					opts = append(opts, ResolvePathForNode(scope.Node, localPath))
+
+					localPath, err = ResolvePathForNode(scope.Node, localPath)
+					if err != nil {
+						return opts, err
+					}
+
+					opts = append(opts, localPath)
 				}
 			default:
 				iopts, err := cg.EmitOptionLookup(ctx, scope, stmt.Call.Func, args, op)
@@ -1316,10 +1331,15 @@ func outputFromWriter(w io.WriteCloser) func(map[string]string) (io.WriteCloser,
 	}
 }
 
-func ResolvePathForNode(node parser.Node, path string) string {
-	if filepath.IsAbs(path) {
-		return path
+func ResolvePathForNode(node parser.Node, path string) (string, error) {
+	path, err := homedir.Expand(path)
+	if err != nil {
+		return path, err
 	}
 
-	return filepath.Join(filepath.Dir(node.Position().Filename), path)
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+
+	return filepath.Join(filepath.Dir(node.Position().Filename), path), nil
 }

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -76,7 +76,7 @@ func TestCodeGen(t *testing.T) {
 			id, err := cg.LocalID(".")
 			require.NoError(t, err)
 
-			return Expect(t, llb.Local(id, llb.SessionID(cg.SessionID())))
+			return Expect(t, llb.Local(id, llb.SessionID(cg.SessionID()), llb.SharedKeyHint(".")))
 		},
 	}, {
 		"local env",

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/logrusorgru/aurora v0.0.0-20191116043053-66b7ad493a23
 	github.com/mattn/go-isatty v0.0.11
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.7.1-0.20200409032528-226a5db9ad3d
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/pkcs11 v0.0.0-20190322140431-074fd7a1ed19 h1:UEWeJCqsIp+93IcMCuqA3KFln2LAUd/tDtoItl0bgJM=
 github.com/miekg/pkcs11 v0.0.0-20190322140431-074fd7a1ed19/go.mod h1:WCBAbTOdfhHhz7YXujeZMF7owC4tPb1naKFsgfUISjo=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/hashstructure v0.0.0-20170609045927-2bca23e0e452/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=


### PR DESCRIPTION
- Paths are resolved to the module's filepath. So you can import modules and execute them without all the relative paths incorrect. See: https://github.com/hinshun/earthly/commit/d4ca01bda635eb24b3360ece9c9555e0707b9fdc
- Also supports home dir resolving via `go-homedir` (Fixes #2)
```hlb
fs homeConfiguration() {
  local "~/.myconfig"
}
```
- Supply `llb.SharedKeyHint` so that different relative strings that are pointing to the same underlying directory are deduplicated when transferring to BuildKit.

```hlb
# build.hlb
fs default() {
    local "."
}
```

```hlb
# subdir/build.hlb
fs default() {
    local "../"
}
```