### PR TITLE
Fix frontend builtin and exiting when progress returns error

### DIFF
--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -168,7 +168,7 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, opts RunOpti
 			return err
 		}
 
-		if opts.Debug {
+		if solveReq == nil || opts.Debug {
 			return nil
 		}
 	}

--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -203,7 +203,7 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 			return llb.Local(id, opts...), nil
 		}
 	case "frontend":
-		fcurce, err := cg.EmitStringExpr(ctx, scope, args[0])
+		source, err := cg.EmitStringExpr(ctx, scope, args[0])
 		if err != nil {
 			return fc, err
 		}
@@ -235,7 +235,7 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 						req := gateway.SolveRequest{
 							Frontend: "gateway.v0",
 							FrontendOpt: map[string]string{
-								"fcurce": fcurce,
+								"source": source,
 							},
 							FrontendInputs: make(map[string]*pb.Definition),
 						}


### PR DESCRIPTION
- Fixes the replace that changed `source` to `fcrce` from a previous PR.
- Returns when progress returned and error and `solveReq` is nil.