### PR TITLE
add localOs, localArch, and localCwd builtins

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -434,10 +434,19 @@ var (
 							parser.NewField(parser.Str, "values", true),
 						},
 					},
+					"localArch": FuncLookup{
+						Params: []*parser.Field{},
+					},
+					"localCwd": FuncLookup{
+						Params: []*parser.Field{},
+					},
 					"localEnv": FuncLookup{
 						Params: []*parser.Field{
 							parser.NewField(parser.Str, "key", false),
 						},
+					},
+					"localOs": FuncLookup{
+						Params: []*parser.Field{},
 					},
 					"template": FuncLookup{
 						Params: []*parser.Field{

--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"text/template"
 
@@ -621,6 +622,14 @@ func (cg *CodeGen) EmitStringChainStmt(ctx context.Context, scope *parser.Scope,
 		return func(_ string) (string, error) {
 			return fmt.Sprintf(formatStr, as...), nil
 		}, nil
+	case "localArch":
+		return func(_ string) (string, error) {
+			return runtime.GOARCH, nil
+		}, nil
+	case "localCwd":
+		return func(_ string) (string, error) {
+			return os.Getwd()
+		}, nil
 	case "localEnv":
 		key, err := cg.EmitStringExpr(ctx, scope, args[0])
 		if err != nil {
@@ -629,6 +638,10 @@ func (cg *CodeGen) EmitStringChainStmt(ctx context.Context, scope *parser.Scope,
 
 		return func(_ string) (string, error) {
 			return os.Getenv(key), nil
+		}, nil
+	case "localOs":
+		return func(_ string) (string, error) {
+			return runtime.GOOS, nil
 		}, nil
 	case "template":
 		text, err := cg.EmitStringExpr(ctx, scope, args[0])

--- a/language/builtin.hlb
+++ b/language/builtin.hlb
@@ -494,11 +494,26 @@ fs downloadDockerTarball(string localPath, string ref)
 # @return the resulting string from formatting.
 string format(string formatString, variadic string values)
 
+# The architecture for the clients local environment.
+#
+# @return the Arch
+string localArch()
+
+# The current working directory from the clients local environment.
+#
+# @return current working directory
+string localCwd()
+
 # An environment variable from the client's local environment.
 #
 # @param key the environment variable's key.
 # @return the environment variable's value
 string localEnv(string key)
+
+# The OS from the clients local environment.
+#
+# @return the OS
+string localOs()
 
 # Process text as a Go text template.
 # For template syntax documentation see:


### PR DESCRIPTION
I want to have a `hlb run` that automatically cross compiles for my current platform (darwin) but I need to pass in my local OS and Arch to the build graph.

Also I think there are some use-cases where `cwd` is relevent for building/exporting files back to the local workspace. `gdb` for example will only read source files if the strings embedded in the binary headers match the local system paths, so debugging a binary built in `/src` will not be easy if the sources are actually in `$HOME/project/src`.  With `localCwd` it will allow for patterns like:
```
fs build() {
  run "make" with option {
    dir localCwd
    mount fs { local "."; } localCwd
  }
}
```