### PR TITLE
Fix group blocks from dropping errors

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -366,7 +366,7 @@ func (cg *CodeGen) EmitStringBlock(ctx context.Context, scope *parser.Scope, stm
 
 func (cg *CodeGen) EmitGroupBlock(ctx context.Context, scope *parser.Scope, stmts []*parser.Stmt, ac aliasCallback, chainStart interface{}) (solver.Request, error) {
 	v, err := cg.EmitBlock(ctx, scope, parser.Group, stmts, ac, chainStart)
-	if v == nil {
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
```hlb
fs a() {
	image string {
		template "{{ invalid }}"
	}
}

group b() {
	image string {
		template "{{ invalid }}"
	}
}
```

```sh
$ hlb run -t a foo.hlb
[+] Building 0.0s (1/1) FINISHED
 => ERROR compiling [a]                                                                                                                                               0.0s
------
 > compiling [a]:
#1 0.000 Caused by: template: foo.hlb:3:3:1: function "invalid" not defined
------

$ hlb run -t b foo.hlb
[+] Building 0.0s (1/1) FINISHED
 => ERROR compiling [b]                                                                                                                                               0.0s
------
 > compiling [b]:
#1 0.000 Caused by: template: foo.hlb:9:3:1: function "invalid" not defined
------
```