### PR TITLE
Coerce fs func lit into group func lit

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -319,12 +319,7 @@ func (c *checker) checkBlockStmt(scope *parser.Scope, typ parser.ObjType, block 
 		// If the function is not a builtin, retrieve it from the scope and then
 		// type check it.
 		_, ok := builtin.Lookup.ByType[typ].Func[name]
-		if !ok && typ == parser.Group {
-			_, ok = builtin.Lookup.ByType[parser.Filesystem].Func[name]
-		}
-
 		if !ok {
-
 			obj := scope.Lookup(name)
 			if obj == nil {
 				return ErrIdentNotDefined{Ident: call.Func.Ident}
@@ -536,6 +531,10 @@ func (c *checker) checkBasicLitArg(typ parser.ObjType, lit *parser.BasicLit) err
 }
 
 func (c *checker) checkFuncLitArg(scope *parser.Scope, typ parser.ObjType, lit *parser.FuncLit) error {
+	if typ == parser.Group && lit.Type.ObjType == parser.Filesystem {
+		typ = lit.Type.ObjType
+	}
+
 	err := c.checkType(lit, typ, lit.Type)
 	if err != nil {
 		return err

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -297,6 +297,40 @@ func TestChecker_Check(t *testing.T) {
 				Name: "myFunction",
 			},
 		},
+	}, {
+		// Until we support func literals as stmts, we have to use a parallel
+		// group of one element to coerce fs to group.
+		"basic group support",
+		`
+		group default() {
+			parallel groupA fs { image "b"; }
+			groupC
+		}
+		group groupA() {
+			parallel fs { image "a"; }
+		}
+		group groupC() {
+			parallel fs { image "c"; }
+		}
+		`,
+		nil,
+	}, {
+		"errors when fs statement is called in a group block",
+		`
+		group badGroup() {
+			image "alpine"
+		}
+		`,
+		ErrIdentNotDefined{
+			Ident: &parser.Ident{
+				Pos: lexer.Position{
+					Filename: "<stdin>",
+					Line:     2,
+					Column:   1,
+				},
+				Name: "image",
+			},
+		},
 	}} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -696,7 +696,7 @@ func (cg *CodeGen) EmitGroupChainStmt(ctx context.Context, scope *parser.Scope, 
 	case "parallel":
 		var peerRequests []solver.Request
 		for _, arg := range args {
-			request, err := cg.EmitGroupExpr(ctx, scope, arg, ac, nil)
+			request, err := cg.EmitGroupExpr(ctx, scope, arg, ac)
 			if err != nil {
 				return gc, err
 			}

--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -705,7 +705,11 @@ func (cg *CodeGen) EmitGroupChainStmt(ctx context.Context, scope *parser.Scope, 
 		}
 
 		gc = func(requests []solver.Request) ([]solver.Request, error) {
-			requests = append(requests, solver.Parallel(peerRequests...))
+			if len(peerRequests) == 1 {
+				requests = append(requests, peerRequests[0])
+			} else {
+				requests = append(requests, solver.Parallel(peerRequests...))
+			}
 			return requests, nil
 		}
 	default:

--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -709,34 +709,6 @@ func (cg *CodeGen) EmitGroupChainStmt(ctx context.Context, scope *parser.Scope, 
 			return requests, nil
 		}
 	default:
-		so, err := cg.EmitFilesystemBuiltinChainStmt(ctx, scope, expr, args, with, ac, nil)
-		if err != nil {
-			return gc, err
-		}
-
-		if so != nil {
-			return func(requests []solver.Request) ([]solver.Request, error) {
-				st, err := so(llb.Scratch())
-				if err != nil {
-					return requests, err
-				}
-
-				request, err := cg.outputRequest(ctx, st, Output{})
-				if err != nil {
-					return requests, err
-				}
-
-				if len(cg.requests) > 0 {
-					request = solver.Parallel(append([]solver.Request{request}, cg.requests...)...)
-				}
-
-				cg.reset()
-
-				requests = append(requests, request)
-				return requests, nil
-			}, nil
-		}
-
 		// Must be a named reference.
 		obj := scope.Lookup(expr.Name())
 		if obj == nil {

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -140,8 +140,8 @@ func TestCodeGen(t *testing.T) {
 		[]string{"default"},
 		`
 		group default() {
-			image "alpine"
-			image "busybox"
+			parallel fs { image "alpine"; }
+			parallel fs { image "busybox"; }
 		}
 		`,
 		func(t *testing.T, cg *CodeGen) solver.Request {
@@ -155,9 +155,9 @@ func TestCodeGen(t *testing.T) {
 		[]string{"default"},
 		`
 		group default() {
-			parallel group {
+			parallel fs {
 				image "alpine"
-			} group {
+			} fs {
 				image "busybox"
 			}
 		}
@@ -173,13 +173,13 @@ func TestCodeGen(t *testing.T) {
 		[]string{"default"},
 		`
 		group default() {
-			image "golang:alpine"
-			parallel group {
+			parallel fs { image "golang:alpine"; }
+			parallel fs {
 				image "alpine"
-			} group {
+			} fs {
 				image "busybox"
 			}
-			image "node:alpine"
+			parallel fs { image "node:alpine"; }
 		}
 		`,
 		func(t *testing.T, cg *CodeGen) solver.Request {
@@ -201,8 +201,12 @@ func TestCodeGen(t *testing.T) {
 		}
 
 		group foo(string ref) {
-			image string { format "alpine:%s" ref; }
-			image string { format "busybox:%s" ref; }
+			parallel fs {
+				image string { format "alpine:%s" ref; }
+			}
+			parallel fs {
+				image string { format "busybox:%s" ref; }
+			}
 		}
 		`,
 		func(t *testing.T, cg *CodeGen) solver.Request {
@@ -216,7 +220,7 @@ func TestCodeGen(t *testing.T) {
 		[]string{"default"},
 		`
 		group default() {
-			parallel group {
+			parallel fs {
 				image "alpine"
 			} fs {
 				scratch

--- a/codegen/decl.go
+++ b/codegen/decl.go
@@ -176,7 +176,7 @@ func (cg *CodeGen) ParameterizedScope(ctx context.Context, scope *parser.Scope, 
 			data = v
 		case parser.Group:
 			var v solver.Request
-			v, err = cg.EmitGroupExpr(ctx, scope, args[i], ac, nil)
+			v, err = cg.EmitGroupExpr(ctx, scope, args[i], ac)
 			data = v
 		}
 		if err != nil {

--- a/parser/cst.go
+++ b/parser/cst.go
@@ -403,9 +403,6 @@ func (t *Type) Equals(typ ObjType) bool {
 		parts := typeParts(typ)
 		return ObjType(parts[0]) == Option
 	}
-	if typ == Group {
-		return t.ObjType == Filesystem || t.ObjType == Group
-	}
 	return t.ObjType == typ
 }
 


### PR DESCRIPTION
- Coerce fs func lit into group func lit
- Add `treeprint` branches for solve options so that they are testable
- Add codegen test

```
group default() {
	parallel group {
		image "alpine"
	} fs {
		scratch
		mkfile "foo" 0o644 "hello world"
		download "."
	}
}
```