### PR TITLE
Allow selectors to be used as arguments

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -396,6 +396,19 @@ func TestChecker_CheckSelectors(t *testing.T) {
 				Name: "invalidSelector",
 			},
 		},
+	}, {
+		"able to use valid selector as mount input",
+		`
+		import myImportedModule "./myModule.hlb"
+	
+		fs badSelectorCaller() {
+			scratch
+			run "xyz" with option {
+				mount myImportedModule.validSelector "/mountpoint"
+			}
+		}
+		`,
+		nil,
 	}} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/checker/errors.go
+++ b/checker/errors.go
@@ -50,12 +50,13 @@ func (e ErrInvalidFunc) Error() string {
 }
 
 type ErrNumArgs struct {
+	Node     parser.Node
 	Expected int
-	CallStmt *parser.CallStmt
+	Actual   int
 }
 
 func (e ErrNumArgs) Error() string {
-	return fmt.Sprintf("%s expected %d args, found %d", FormatPos(e.CallStmt.Pos), e.Expected, len(e.CallStmt.Args))
+	return fmt.Sprintf("%s expected %d args, found %d", FormatPos(e.Node.Position()), e.Expected, e.Actual)
 }
 
 type ErrIdentNotDefined struct {


### PR DESCRIPTION
- Previously cannot use selector as an argument:
```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/openllb/hlb/checker.(*checker).checkCallArgs(0xc00036c4b0, 0xc0002442e0, 0xc0000d3dc0, 0x0, 0x0, 0x0, 0x0, 0x1)
	/home/edgarl/go/src/github.com/openllb/hlb/checker/checker.go:435 +0x2aa
```