### PR TITLE
Set allowed entitlements on solve opt to allow changing network and security mode

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -26,6 +26,7 @@ import (
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/entitlements"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/openllb/hlb/checker"
@@ -912,6 +913,7 @@ func (cg *CodeGen) EmitExecOptions(ctx context.Context, scope *parser.Scope, op 
 					netMode = pb.NetMode_UNSET
 				case "host":
 					netMode = pb.NetMode_HOST
+					cg.solveOpts = append(cg.solveOpts, solver.WithEntitlement(entitlements.EntitlementNetworkHost))
 				case "node":
 					netMode = pb.NetMode_NONE
 				default:
@@ -931,6 +933,7 @@ func (cg *CodeGen) EmitExecOptions(ctx context.Context, scope *parser.Scope, op 
 					securityMode = pb.SecurityMode_SANDBOX
 				case "insecure":
 					securityMode = pb.SecurityMode_INSECURE
+					cg.solveOpts = append(cg.solveOpts, solver.WithEntitlement(entitlements.EntitlementSecurityInsecure))
 				default:
 					return opts, errors.WithStack(ErrCodeGen{args[0], errors.Errorf("unknown security mode")})
 				}

--- a/solver/request.go
+++ b/solver/request.go
@@ -216,7 +216,12 @@ func (o op) Tree(tree treeprint.Tree) error {
 	if o.info.OutputLocalOCITarball {
 		solve.AddNode("downloadOCITarball")
 	}
-
+	if len(o.info.Entitlements) > 0 {
+		ent := solve.AddBranch("entitlements")
+		for _, entitlements := range o.info.Entitlements {
+			ent.AddNode(string(entitlements))
+		}
+	}
 	for _, input := range pbOp.Inputs {
 		if _, ok := reportedInputs[input.Digest]; ok {
 			continue


### PR DESCRIPTION
- Currently, you are not allowed to change `network "host"` or `security "insecure"`. Ported over the `AllowedEntitlements` from `buildctl`.
- However, this still requires the `buildkitd` side to also allow these entitlements, so it won't work on cloud build.
```
#1 DONE 0.0s
ERROR   failed to solve: rpc error: code = Unknown desc = failed to load LLB: security.insecure is not allowed
```