### PR TITLE
allow for directory in arguments to `secret`

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -385,6 +385,16 @@ var (
 							parser.NewField(parser.Int, "filemode", false),
 						},
 					},
+					"includePatterns": FuncLookup{
+						Params: []*parser.Field{
+							parser.NewField(parser.Str, "pattern", true),
+						},
+					},
+					"excludePatterns": FuncLookup{
+						Params: []*parser.Field{
+							parser.NewField(parser.Str, "pattern", true),
+						},
+					},
 				},
 			},
 			"option::ssh": LookupByType{

--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"text/template"
@@ -333,6 +334,11 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		customName := strings.ReplaceAll(shlex, "\n", "")
 		opts = append(opts, llb.Shlex(shlex), llb.WithCustomName(customName))
 
+		err = fixReadonlyMounts(opts)
+		if err != nil {
+			return nil, err
+		}
+
 		fc = func(st llb.State) (llb.State, error) {
 			exec := st.Run(opts...)
 
@@ -586,6 +592,166 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 	}
 
 	return fc, nil
+}
+
+// fixReadonlyMounts will modify the source for readonly mounts so subsequent mounts that
+// mount onto the readonly-mounts will have the mountpoint present.  For example if we
+// have this code:
+//
+// 		run "make" with option {
+//			dir "/src"
+//			mount fs {
+//				local "."
+//			} "/src" with readonly
+//			mount scratch "/src/output" as buildOutput
+//			# ^^^^^ FAIL cannot create `output` directory for mount on readonly FS
+//			secret "./secret/foo.pem" "/src/secret/foo.pem"
+//			# ^^^^^ FAIL cannot create `./secret/foo.pm` for secret on readonly FS
+//		}
+//
+// when containerd tries to mount /src/output on top of the /src mountpoint it will
+// fail because /src is mounted as readonly.  The work around for this is to
+// inline create the mountpoints so that they pre-exist and containerd will not have
+// to create them.  It can be done with HLB like:
+//
+//		run "make" with option {
+//			dir "/src"
+//			mount fs {
+//				local "."
+//				mkdir "output" 0o755 # <-- this is added to ensure mountpoint exists
+//				mkdir "secret" 0o755            # <-- added so the secret can be mounted
+//				mkfile "secret/foo.pm" 0o644 "" # <-- added so the secret can be mounted
+//			} "/src" with readonly
+//			mount scratch "/src/output" as buildOutput
+//		}
+//
+// So this function is effectively automatically adding the `mkdir` and `mkfile` instructions
+// when it detects that a mountpoint is required to be on a readonly FS.
+func fixReadonlyMounts(opts []llb.RunOption) error {
+	// short-circuit if we don't have any readonly mounts
+	haveReadonly := false
+	for _, opt := range opts {
+		if mnt, ok := opt.(*mountRunOption); ok {
+			haveReadonly = mnt.IsReadonly()
+			if haveReadonly {
+				break
+			}
+		}
+	}
+	if !haveReadonly {
+		return nil
+	}
+
+	// collecting run options to look for targets (secrets, mounts) so we can
+	// determine if there are overlapping mounts with readonly attributes
+	mountDetails := make([]struct {
+		Target string
+		Mount  *mountRunOption
+	}, len(opts))
+
+	for i, opt := range opts {
+		switch runOpt := opt.(type) {
+		case *mountRunOption:
+			mountDetails[i].Target = runOpt.Target
+			mountDetails[i].Mount = runOpt
+		case llb.RunOption:
+			ei := llb.ExecInfo{}
+			runOpt.SetRunOption(&ei)
+			if len(ei.Secrets) > 0 {
+				// we only processed one option, so can have at most one secret
+				mountDetails[i].Target = ei.Secrets[0].Target
+				continue
+			}
+		}
+	}
+
+	// madeDirs will keep track of directories we have had to create
+	// so we don't duplicate instructions
+	madeDirs := map[string]struct{}{}
+
+	// if we have readonly mounts and then secrets or other mounts on top of the
+	// readonly mounts then we have to run a mkdir or mkfile on the mount first
+	// before it become readonly
+
+	// now walk the mountDetails backwards and look for common target paths
+	// in prior mounts (mount ordering is significant).
+	for i := len(mountDetails) - 1; i >= 0; i-- {
+		src := mountDetails[i]
+		if src.Target == "" {
+			// not a target option, like `dir "foo"`, so just skip
+			continue
+		}
+		for j := i - 1; j >= 0; j-- {
+			dest := mountDetails[j]
+			if !strings.HasPrefix(src.Target, dest.Target) {
+				// paths not common, skip
+				continue
+			}
+			if dest.Mount == nil {
+				// dest is not a mount, so skip
+				continue
+			}
+			if !dest.Mount.IsReadonly() {
+				// not mounting into readonly fs, so we are good with this mount
+				break
+			}
+
+			// we need to rewrite the mount at opts[j] so that that we mkdir and/or mkfile
+			st := dest.Mount.Source
+			if src.Mount != nil {
+				// this is a mount, so we need to ensure the mount point
+				// directory has been created
+				if _, ok := madeDirs[src.Target]; ok {
+					// already created the dir
+					break
+				}
+				// update local cache so we don't make this dir again
+				madeDirs[dest.Target] = struct{}{}
+
+				relativeDir, err := filepath.Rel(dest.Target, src.Target)
+				if err != nil {
+					return err
+				}
+				st = st.File(
+					llb.Mkdir(relativeDir, os.FileMode(0755), llb.WithParents(true)),
+				)
+			} else {
+				// not a mount, so must be a `secret` which will be a path
+				// to a file, we will need to make the directory for the
+				// secret as well as an empty file to be mounted over
+				dir := filepath.Dir(src.Target)
+				relativeDir := strings.TrimPrefix(dir, dest.Target)
+
+				if _, ok := madeDirs[dir]; !ok {
+					// update local cache so we don't make this dir again
+					madeDirs[dir] = struct{}{}
+
+					st = st.File(
+						llb.Mkdir(relativeDir, os.FileMode(0755), llb.WithParents(true)),
+					)
+				}
+				relativeFile, err := filepath.Rel(dest.Target, src.Target)
+				if err != nil {
+					return err
+				}
+				st = st.File(
+					llb.Mkfile(relativeFile, os.FileMode(0644), []byte{}),
+				)
+			}
+
+			// reset the mount option to include our state with mkdir/mkfile actions
+			opts[j] = &mountRunOption{
+				Target: dest.Target,
+				Source: st,
+				Opts:   dest.Mount.Opts,
+			}
+
+			// save the state for later in case we need to add more mkdir/mkfile actions
+			mountDetails[j].Mount.Source = st
+			break
+		}
+	}
+	return nil
 }
 
 func (cg *CodeGen) EmitStringChainStmt(ctx context.Context, scope *parser.Scope, expr *parser.Expr, args []*parser.Expr, with *parser.WithOpt, chainStart interface{}) (StringChain, error) {

--- a/language/builtin.hlb
+++ b/language/builtin.hlb
@@ -268,6 +268,18 @@ option::secret gid(int id)
 # @return an option to set the permissions of the secure file.
 option::secret mode(int filemode)
 
+# Attach secrets only for files that match any of the included patterns.
+#
+# @param pattern a list of patterns for files that should be attached as secrets
+# @return an option to attach files that match any pattern.
+option::secret includePatterns(variadic string pattern)
+
+# Attach secrets only for files that do not match any of the excluded patterns.
+#
+# @param pattern a list of patterns for files that should not be attached as secrets
+# @return an option to attach files that don't match any pattern.
+option::secret excludePatterns(variadic string pattern)
+
 # Sets the mount to be attached as a read-only filesystem.
 #
 # @return an option to attach the mount as a read-only filesystem..


### PR DESCRIPTION
Also automatically add mount directories for secrets/mounts on top of `readonly` fs

I will add some codegen tests, just wanted to get your thoughts on this.  It seems to work, greatly simplified the mkdir/mkfile copy/paste I had all over so that I could get caching on builds from local inputs.