### PR TITLE
Allow option funcs to be used from imported

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -419,14 +419,38 @@ func TestChecker_CheckSelectors(t *testing.T) {
 		}
 		`,
 		nil,
+	}, {
+		"use imported option",
+		`
+		import myImportedModule "./myModule.hlb"
+	
+		fs default(string foo) {
+			image "busybox" with myImportedModule.resolveImage
+		}
+		`,
+		nil,
+	}, {
+		"merge imported option",
+		`
+		import myImportedModule "./myModule.hlb"
+	
+		fs default(string foo) {
+			image "busybox" with option {
+				myImportedModule.resolveImage
+			}
+		}
+		`,
+		nil,
 	}} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			importedModuleDefinition := `
 				export validSelector
 				export validSelectorWithArgs
+				export resolveImage
 				fs validSelector() {}
 				fs validSelectorWithArgs(string bar) {}
+				option::image resolveImage() { resolve; }
 			`
 
 			importedModule, err := parser.Parse(strings.NewReader(importedModuleDefinition))

--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -82,6 +82,10 @@ func (cg *CodeGen) EmitFilesystemChainStmt(ctx context.Context, scope *parser.Sc
 		case *parser.ImportDecl:
 			importScope := obj.Data.(*parser.Scope)
 			importObj := importScope.Lookup(expr.Selector.Select.Name)
+			if importObj == nil {
+				return nil, errors.WithStack(ErrCodeGen{expr, errors.Errorf("could not find reference")})
+			}
+
 			switch m := importObj.Node.(type) {
 			case *parser.FuncDecl:
 				v, err = cg.EmitFuncDecl(ctx, scope, m, args, ac, chainStart)
@@ -314,7 +318,7 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 				// to be in the context of a specific function run is in.
 			case with.Expr.FuncLit != nil:
 				for _, stmt := range with.Expr.FuncLit.Body.NonEmptyStmts() {
-					if stmt.Call.Func.Ident.Name != "mount" || stmt.Call.Alias == nil {
+					if stmt.Call.Func.Name() != "mount" || stmt.Call.Alias == nil {
 						continue
 					}
 

--- a/codegen/debug.go
+++ b/codegen/debug.go
@@ -149,7 +149,7 @@ func NewDebugger(c *client.Client, w io.Writer, r *bufio.Reader, ibs map[string]
 								Func: n,
 							}
 						case *parser.CallStmt:
-							if n.Func.Ident.Name == "breakpoint" {
+							if n.Func.Name() == "breakpoint" {
 								fmt.Fprintf(w, "%s cannot break at breakpoint\n", checker.FormatPos(n.Pos))
 								continue
 							}

--- a/parser/cst.go
+++ b/parser/cst.go
@@ -357,13 +357,17 @@ func (e *Expr) End() lexer.Position {
 }
 
 func (e *Expr) Name() string {
+	return e.IdentNode().Name
+}
+
+func (e *Expr) IdentNode() *Ident {
 	switch {
 	case e.Selector != nil:
-		return e.Selector.Ident.Name
+		return e.Selector.Ident
 	case e.Ident != nil:
-		return e.Ident.Name
+		return e.Ident
 	default:
-		return ""
+		return &Ident{}
 	}
 }
 


### PR DESCRIPTION
- Previously didn't allow `run "echo foo" with myimport.foo`
- We need some way of running codegen tests with imports, but going to take more work since we need a sandboxed buildkitd or some small mock framework for imports.