### PR TITLE
Construct function scope, and so forth for duplicate declarations

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -40,19 +40,13 @@ func (c *checker) Check(mod *parser.Module) error {
 			}
 		case *parser.ImportDecl:
 			if n.Ident != nil {
-				skip := c.registerDecl(mod.Scope, n.Ident, n)
-				if skip {
-					return false
-				}
+				c.registerDecl(mod.Scope, n.Ident, n)
 			}
 		case *parser.FuncDecl:
 			fun := n
 
 			if fun.Name != nil {
-				skip := c.registerDecl(mod.Scope, fun.Name, fun)
-				if skip {
-					return false
-				}
+				c.registerDecl(mod.Scope, fun.Name, fun)
 			}
 
 			// Create a function-level scope.
@@ -236,7 +230,7 @@ func (c *checker) CheckSelectors(mod *parser.Module) error {
 	return nil
 }
 
-func (c *checker) registerDecl(scope *parser.Scope, ident *parser.Ident, node parser.Node) bool {
+func (c *checker) registerDecl(scope *parser.Scope, ident *parser.Ident, node parser.Node) {
 	// Ensure that this identifier is not already defined in the module scope.
 	obj := scope.Lookup(ident.Name)
 	if obj != nil {
@@ -244,7 +238,7 @@ func (c *checker) registerDecl(scope *parser.Scope, ident *parser.Ident, node pa
 			c.duplicateDecls = append(c.duplicateDecls, obj.Ident)
 		}
 		c.duplicateDecls = append(c.duplicateDecls, ident)
-		return true
+		return
 	}
 
 	scope.Insert(&parser.Object{
@@ -252,7 +246,6 @@ func (c *checker) registerDecl(scope *parser.Scope, ident *parser.Ident, node pa
 		Ident: ident,
 		Node:  node,
 	})
-	return false
 }
 
 func (c *checker) checkFieldList(fields []*parser.Field) error {

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -189,8 +189,10 @@ func TestChecker_Check(t *testing.T) {
 	}, {
 		"errors with duplicate function names",
 		`
-		fs duplicateFunctionName() {}
-		fs duplicateFunctionName() {}
+		fs duplicate(string ref) {}
+		fs duplicate(string ref) {
+			image ref
+		}
 		`,
 		ErrDuplicateDecls{
 			Idents: []*parser.Ident{{
@@ -199,7 +201,7 @@ func TestChecker_Check(t *testing.T) {
 					Line:     1,
 					Column:   4,
 				},
-				Name: "duplicateFunctionName",
+				Name: "duplicate",
 			}},
 		},
 	}, {
@@ -478,17 +480,10 @@ func TestChecker_CheckSelectors(t *testing.T) {
 	}
 }
 
-func validateError(t *testing.T, expectedError error, actualError error) {
-	if expectedError == nil {
-		require.NoError(t, actualError)
+func validateError(t *testing.T, expected error, actual error) {
+	if expected == nil {
+		require.NoError(t, actual)
 	} else {
-		// assume if we got a semantic error we really want
-		// to validate the underlying error
-		if semErr, ok := actualError.(ErrSemantic); ok {
-			require.IsType(t, expectedError, semErr.Errs[0])
-			require.Equal(t, expectedError.Error(), semErr.Errs[0].Error())
-		} else {
-			require.IsType(t, expectedError, actualError)
-		}
+		require.Equal(t, expected.Error(), actual.Error())
 	}
 }


### PR DESCRIPTION
- Panics because `fun.Scope` is nil when duplicate decl is encountered
- We had two choices here: 1) Exit early when encountering duplicate declarations, but that means other errors won't show up, 2) Don't override scope with duplicate but continue constructing scope, etc. I chose (2) so that we show other errors too.
- `validateError` was hiding other errors because it only checked the first element, I think checking `expected.Error()` vs `actual.Error()` was sufficient because `ErrSemantic` with one element has the same output.