### PR TITLE
Return error on bad lookups during codegen

### DIFF
--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -82,7 +82,7 @@ func (cg *CodeGen) EmitFilesystemChainStmt(ctx context.Context, scope *parser.Sc
 		// Must be a named reference.
 		obj := scope.Lookup(expr.Name())
 		if obj == nil {
-			return fc, errors.WithStack(ErrCodeGen{expr, errors.Errorf("could not find reference")})
+			return fc, errors.WithStack(ErrCodeGen{expr.IdentNode(), ErrUndefinedReference})
 		}
 
 		var v interface{}
@@ -96,7 +96,7 @@ func (cg *CodeGen) EmitFilesystemChainStmt(ctx context.Context, scope *parser.Sc
 			importScope := obj.Data.(*parser.Scope)
 			importObj := importScope.Lookup(expr.Selector.Select.Name)
 			if importObj == nil {
-				return nil, errors.WithStack(ErrCodeGen{expr, errors.Errorf("could not find reference")})
+				return nil, errors.WithStack(ErrCodeGen{expr.Selector, ErrUndefinedReference})
 			}
 
 			switch m := importObj.Node.(type) {
@@ -910,7 +910,7 @@ func (cg *CodeGen) EmitStringChainStmt(ctx context.Context, scope *parser.Scope,
 		// Must be a named reference.
 		obj := scope.Lookup(expr.Name())
 		if obj == nil {
-			return nil, errors.WithStack(ErrCodeGen{expr, errors.Errorf("could not find reference")})
+			return nil, errors.WithStack(ErrCodeGen{expr.IdentNode(), ErrUndefinedReference})
 		}
 
 		var v interface{}
@@ -923,6 +923,10 @@ func (cg *CodeGen) EmitStringChainStmt(ctx context.Context, scope *parser.Scope,
 		case *parser.ImportDecl:
 			importScope := obj.Data.(*parser.Scope)
 			importObj := importScope.Lookup(expr.Selector.Select.Name)
+			if importObj == nil {
+				return nil, errors.WithStack(ErrCodeGen{expr.Selector, ErrUndefinedReference})
+			}
+
 			switch m := importObj.Node.(type) {
 			case *parser.FuncDecl:
 				v, err = cg.EmitFuncDecl(ctx, scope, m, args, noopAliasCallback, chainStart)
@@ -974,7 +978,7 @@ func (cg *CodeGen) EmitGroupChainStmt(ctx context.Context, scope *parser.Scope, 
 		// Must be a named reference.
 		obj := scope.Lookup(expr.Name())
 		if obj == nil {
-			return gc, errors.WithStack(ErrCodeGen{expr, errors.Errorf("could not find reference")})
+			return gc, errors.WithStack(ErrCodeGen{expr.IdentNode(), ErrUndefinedReference})
 		}
 
 		var v interface{}
@@ -986,6 +990,10 @@ func (cg *CodeGen) EmitGroupChainStmt(ctx context.Context, scope *parser.Scope, 
 		case *parser.ImportDecl:
 			importScope := obj.Data.(*parser.Scope)
 			importObj := importScope.Lookup(expr.Selector.Select.Name)
+			if importObj == nil {
+				return gc, errors.WithStack(ErrCodeGen{expr.Selector, ErrUndefinedReference})
+			}
+
 			switch m := importObj.Node.(type) {
 			case *parser.FuncDecl:
 				v, err = cg.EmitFuncDecl(ctx, scope, m, args, ac, chainStart)

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -485,6 +485,10 @@ func (cg *CodeGen) EmitImageOptions(ctx context.Context, scope *parser.Scope, op
 
 func (cg *CodeGen) EmitOptionLookup(ctx context.Context, scope *parser.Scope, expr *parser.Expr, args []*parser.Expr, op string) (opts []interface{}, err error) {
 	obj := scope.Lookup(expr.Name())
+	if obj == nil {
+		return opts, errors.WithStack(ErrCodeGen{expr.IdentNode(), ErrUndefinedReference})
+	}
+
 	switch obj.Kind {
 	case parser.DeclKind:
 		switch n := obj.Node.(type) {
@@ -493,6 +497,10 @@ func (cg *CodeGen) EmitOptionLookup(ctx context.Context, scope *parser.Scope, ex
 		case *parser.ImportDecl:
 			importScope := obj.Data.(*parser.Scope)
 			importObj := importScope.Lookup(expr.Selector.Select.Name)
+			if importObj == nil {
+				return opts, errors.WithStack(ErrCodeGen{expr.Selector, ErrUndefinedReference})
+			}
+
 			switch m := importObj.Node.(type) {
 			case *parser.FuncDecl:
 				return cg.EmitOptionFuncDecl(ctx, scope, m, args)

--- a/codegen/errors.go
+++ b/codegen/errors.go
@@ -9,7 +9,15 @@ import (
 )
 
 var (
+	// ErrBadCast is returned when codegen was unable to cast an interface to an
+	// expected type. Type checking should occur in the checker so that's often
+	// where the bug should be fixed, but it may be in the codegen.
 	ErrBadCast = errors.Errorf("bad cast")
+
+	// ErrUndefinedReference is returned when codegen was unable to lookup an
+	// object for a scope. Lexical scope checking should occur in the checker so
+	// that's often where the bug shuold be fixed, but it may be in the codegen.
+	ErrUndefinedReference = errors.Errorf("undefined reference")
 )
 
 type ErrCodeGen struct {

--- a/codegen/expr.go
+++ b/codegen/expr.go
@@ -33,7 +33,11 @@ func (cg *CodeGen) EmitStringExpr(ctx context.Context, scope *parser.Scope, expr
 func (cg *CodeGen) EmitIntExpr(ctx context.Context, scope *parser.Scope, expr *parser.Expr) (int, error) {
 	switch {
 	case expr.Ident != nil:
-		obj := scope.Lookup(expr.Ident.Name)
+		obj := scope.Lookup(expr.Name())
+		if obj == nil {
+			return 0, errors.WithStack(ErrCodeGen{expr.IdentNode(), ErrUndefinedReference})
+		}
+
 		switch obj.Kind {
 		case parser.DeclKind:
 			panic("unimplemented")
@@ -61,7 +65,11 @@ func (cg *CodeGen) EmitIntExpr(ctx context.Context, scope *parser.Scope, expr *p
 func (cg *CodeGen) EmitBoolExpr(ctx context.Context, scope *parser.Scope, expr *parser.Expr) (bool, error) {
 	switch {
 	case expr.Ident != nil:
-		obj := scope.Lookup(expr.Ident.Name)
+		obj := scope.Lookup(expr.Name())
+		if obj == nil {
+			return false, errors.WithStack(ErrCodeGen{expr.IdentNode(), ErrUndefinedReference})
+		}
+
 		switch obj.Kind {
 		case parser.DeclKind:
 			panic("unimplemented")


### PR DESCRIPTION
- Instead of panicking with nil dereference, show the source mapping and stack for the error.