### PR TITLE
Fix remote imports that have frontend codegen

### DIFF
--- a/module/resolve.go
+++ b/module/resolve.go
@@ -178,7 +178,7 @@ type remoteResolver struct {
 }
 
 func (r *remoteResolver) Resolve(ctx context.Context, scope *parser.Scope, decl *parser.ImportDecl) (Resolved, error) {
-	cg, err := codegen.New()
+	cg, err := codegen.New(codegen.WithClient(r.cln), codegen.WithMultiWriter(r.mw))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Currently I can't import a frontend like so:
```hlb
import hlbgen from fs {
    frontend "hinshun/hlbgen"
}
```
- The remote resolver should pass the client and multiwriter it already has.