### PR TITLE
add `always` builtin for `run` to force command to always run (but allow cached mounts)

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -1042,7 +1042,7 @@ func (cg *CodeGen) EmitExecOptions(ctx context.Context, scope *parser.Scope, op 
 
 				opts = append(opts, llb.User(name))
 			case "ignoreCache":
-				opts = append(opts, llb.IgnoreCache)
+				opts = append(opts, llb.AddEnv("HLB_IGNORE_CACHE", identity.NewID()))
 			case "network":
 				mode, err := cg.EmitStringExpr(ctx, scope, args[0])
 				if err != nil {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -537,7 +537,6 @@ Adds a host entry to /etc/hosts for the duration of the run command.
 
 
 Ignore any previously cached results for the run command.
-@ return an option to ignore existing cache for the run command.
 
 #### <span class='hlb-type'>option::run</span> <span class='hlb-name'>mount</span>(<span class='hlb-type'>fs</span> <span class='hlb-variable'>input</span>, <span class='hlb-type'>string</span> <span class='hlb-variable'>mountPoint</span>)
 

--- a/language/builtin.hlb
+++ b/language/builtin.hlb
@@ -146,7 +146,7 @@ option::run user(string name)
 
 # Ignore any previously cached results for the run command.
 #
-# @ return an option to ignore existing cache for the run command.
+# @return an option to ignore existing cache for the run command.
 option::run ignoreCache()
 
 # Sets the networking mode for the duration of the run command. By default, the


### PR DESCRIPTION
The implementation is a bit of a hack.  There does not seem to be a way via llb to make an exec call force a cache-miss other than `llb.IgnoreCache`, but that will also prevent any mounts from also using cache. 

So this PR adds a random env var so that the vertex will always hash to a new digest while still allowing mount cache to be used.