### PR TITLE
Fix download file outputs and hidden error

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -321,7 +321,7 @@ func (cg *CodeGen) EmitBlock(ctx context.Context, scope *parser.Scope, typ parse
 			}
 		}
 		if cerr != nil {
-			return v, err
+			return v, cerr
 		}
 
 		if call.Alias != nil {

--- a/codegen/output.go
+++ b/codegen/output.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
@@ -121,7 +122,12 @@ func (cg *CodeGen) outputRequest(ctx context.Context, st llb.State, output Outpu
 		s.Allow(filesync.NewFSSyncTargetDir(output.LocalPath))
 		opts = append(opts, solver.WithDownload(output.LocalPath))
 	case OutputDownloadTarball, OutputDownloadOCITarball, OutputDownloadDockerTarball:
-		f, err := os.Open(output.LocalPath)
+		err = os.MkdirAll(filepath.Dir(output.LocalPath), 0755)
+		if err != nil {
+			return nil, err
+		}
+
+		f, err := os.Create(output.LocalPath)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- `downloadTarball`, `downloadOCITarball`, and `downloadDockerTarball` did not successfully download files.
- Errors from this code path were also being dropped because `err` was returned (which was `nil`) instead of `cerr`.