### PR TITLE
[#134] resolve for remote platform, not client platform

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -444,7 +444,11 @@ func (cg *CodeGen) EmitImageOptions(ctx context.Context, scope *parser.Scope, op
 					return opts, err
 				}
 				if v {
-					opts = append(opts, imagemetaresolver.WithDefault)
+					opts = append(opts, llb.WithMetaResolver(
+						imagemetaresolver.New(
+							imagemetaresolver.WithDefaultPlatform(&specs.Platform{OS: "linux", Architecture: "amd64"}),
+						),
+					))
 				}
 			default:
 				iopts, err := cg.EmitOptionLookup(ctx, scope, stmt.Call.Func, args, op)


### PR DESCRIPTION
fixes #134

You were right, the `imagemetaresolver.WithDefault` was resolving for my client platform (Darwin) while it needs to be resolving for the deployment platform.  We will likely need to make all these hard-coded linux/amd64 arguments configurable for when we have non-linux remote cloudbuild systems, but for now it seems okay.