### PR TITLE
Catch default errors to avoid syntax 0:0 errors

### DIFF
--- a/report/syntax.go
+++ b/report/syntax.go
@@ -45,6 +45,8 @@ func NewSyntaxError(color aurora.Aurora, ib *IndexedBuffer, lex *lexer.PeekingLe
 			group, err = errBlockStart(color, ib, lex, unexpected)
 		case `"}"`:
 			group, err = errBlockEnd(color, ib, lex, unexpected)
+		default:
+			group, err = errDefault(color, ib, lex, perr, unexpected)
 		}
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes #145
Fixes #146

```sh
 --> foo.hlb:3:40: syntax error
  |
3 |                 format "%s/%s" "alpine", "git"
  |                                        ^
  |                                        unexpected token "," (expected ";" | <newline> | <comment>)
```

```sh
 --> foo.hlb:2:25: syntax error
  |
2 |         image "busybox" {
  |                         ^
  |                         unexpected token "{" (expected ";" | <newline> | <comment>)
```

```sh
 --> foo.hlb:2:38: syntax error
  |
2 |         image "busybox" with hoption {
  |                                      ^
  |                                      unexpected token "{" (expected ";" | <newline> | <comment>)
```

```sh
 --> foo.hlb:2:18: syntax error
  |
2 | 	image "busybox" with option resolve
  | 	                ^^^^
  | 	                unexpected token "with" (expected ";" | <newline> | <comment>)
```