### PR TITLE
Handle when frontend returns no ref

### DIFF
--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -344,7 +344,12 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 							return res, err
 						}
 
-						st, err = ref.ToState()
+						if ref == nil {
+							st = llb.Scratch()
+						} else {
+							st, err = ref.ToState()
+						}
+
 						return res, err
 					})
 				})

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -317,7 +317,7 @@ func (cg *CodeGen) EmitBlock(ctx context.Context, scope *parser.Scope, typ parse
 		var cerr error
 		v, cerr = chain(v)
 		if cerr == nil || errors.As(cerr, &ErrBindingCycle{}) {
-			if st, ok := v.(llb.State); ok && st.Output() != nil {
+			if st, ok := v.(llb.State); ok && st.Output() != nil && st.Output().Vertex(ctx) != nil {
 				err = st.Validate(ctx)
 				if err != nil {
 					return v, ErrCodeGen{Node: stmt, Err: err}


### PR DESCRIPTION
Specifically this segfaults because the gateway frontend returns no ref due to `FROM scratch`:

```hlb
fs dockerfile() {
	scratch
	mkfile "/Dockerfile" 0o666 "FROM scratch"
}

fs default() {
	frontend "docker/dockerfile:latest" with option {
		input "context" scratch
		input "dockerfile" dockerfile
	}
}
```

```sh
github.com/openllb/hlb/codegen.(*CodeGen).EmitFilesystemBuiltinChainStmt.func7.1.2.1(0x1dcd920, 0xc000454240, 0x1dcde20, 0xc0004ba100, 0x0, 0xc0004ba100, 0x27)
	/Users/josh/Work/hlb/codegen/chain.go:347 +0x29d
```