### PR TITLE
Fix deadlock with remote resolver when other errgroup routines fails

### DIFF
--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -669,7 +669,7 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 		fc = func(st llb.State) (llb.State, error) {
 			var dgst string
 			request, err := cg.outputRequest(ctx, st, Output{Type: OutputDockerPush, Ref: ref},
-				solver.WithCallback(func(resp *client.SolveResponse) error {
+				solver.WithCallback(func(_ context.Context, resp *client.SolveResponse) error {
 					dgst = resp.ExporterResponse[keyContainerImageDigest]
 					return nil
 				}),

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -1142,9 +1142,9 @@ func (cg *CodeGen) EmitExecOptions(ctx context.Context, scope *parser.Scope, op 
 						return opts, errors.Wrap(err, "failed to listen on forwarding sock")
 					}
 
-					g, _ := errgroup.WithContext(ctx)
+					g, ctx := errgroup.WithContext(ctx)
 
-					cg.SolveOpts = append(cg.SolveOpts, solver.WithCallback(func(*client.SolveResponse) error {
+					cg.SolveOpts = append(cg.SolveOpts, solver.WithCallback(func(context.Context, *client.SolveResponse) error {
 						defer os.RemoveAll(dir)
 
 						err := l.Close()
@@ -1160,7 +1160,7 @@ func (cg *CodeGen) EmitExecOptions(ctx context.Context, scope *parser.Scope, op 
 
 						// ErrNetClosing is hidden in an internal golang package:
 						// https://golang.org/src/internal/poll/fd.go
-						err := RunSockProxy(conn, l)
+						err := RunSockProxy(ctx, conn, l)
 						if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
 							return err
 						}

--- a/codegen/output.go
+++ b/codegen/output.go
@@ -104,8 +104,12 @@ func (cg *CodeGen) outputRequest(ctx context.Context, st llb.State, output Outpu
 		s.Allow(filesync.NewFSSyncTarget(outputFromWriter(w)))
 
 		done := make(chan struct{})
-		opts = append(opts, solver.WithCallback(func(*client.SolveResponse) error {
-			<-done
+		opts = append(opts, solver.WithCallback(func(ctx context.Context, _ *client.SolveResponse) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-done:
+			}
 			return nil
 		}))
 

--- a/codegen/sockproxy.go
+++ b/codegen/sockproxy.go
@@ -1,12 +1,19 @@
 package codegen
 
 import (
+	"context"
 	"io"
 	"net"
 )
 
-func RunSockProxy(conn net.Conn, l net.Listener) error {
+func RunSockProxy(ctx context.Context, conn net.Conn, l net.Listener) error {
 	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
 		proxy, err := l.Accept()
 		if err != nil {
 			return err

--- a/solver/solve.go
+++ b/solver/solve.go
@@ -168,8 +168,6 @@ func Build(ctx context.Context, c *client.Client, s *session.Session, pw progres
 		})
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
-
 	var (
 		statusCh chan *client.SolveStatus
 		resp     *client.SolveResponse
@@ -179,17 +177,12 @@ func Build(ctx context.Context, c *client.Client, s *session.Session, pw progres
 		statusCh = pw.Status()
 	}
 
-	g.Go(func() (err error) {
-		resp, err = c.Build(ctx, solveOpt, "", f, statusCh)
-		return err
-	})
-
-	err := g.Wait()
+	resp, err := c.Build(ctx, solveOpt, "", f, statusCh)
 	if err != nil {
 		return err
 	}
 
-	g, ctx = errgroup.WithContext(ctx)
+	g, ctx := errgroup.WithContext(ctx)
 
 	for _, fn := range info.Callbacks {
 		fn := fn

--- a/solver/solve.go
+++ b/solver/solve.go
@@ -17,7 +17,7 @@ import (
 
 type SolveOption func(*SolveInfo) error
 
-type SolveCallback func(resp *client.SolveResponse) error
+type SolveCallback func(ctx context.Context, resp *client.SolveResponse) error
 
 type SolveInfo struct {
 	OutputDockerRef       string
@@ -187,7 +187,7 @@ func Build(ctx context.Context, c *client.Client, s *session.Session, pw progres
 	for _, fn := range info.Callbacks {
 		fn := fn
 		g.Go(func() error {
-			return fn(resp)
+			return fn(ctx, resp)
 		})
 	}
 


### PR DESCRIPTION
- Fixes local import path for subdirectories to include subdirectory twice
- Removes unnecessary errgroup for solver.Build when it used to handle sessions