### PR TITLE
Refactor ObjType and typ to Kind and kind

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -5,10 +5,10 @@ package builtin
 import "github.com/openllb/hlb/parser"
 
 type BuiltinLookup struct {
-	ByType map[parser.ObjType]LookupByType
+	ByKind map[parser.Kind]LookupByKind
 }
 
-type LookupByType struct {
+type LookupByKind struct {
 	Func map[string]FuncLookup
 }
 
@@ -19,8 +19,8 @@ type FuncLookup struct {
 
 var (
 	Lookup = BuiltinLookup{
-		ByType: map[parser.ObjType]LookupByType{
-			parser.Filesystem: LookupByType{
+		ByKind: map[parser.Kind]LookupByKind{
+			parser.Filesystem: LookupByKind{
 				Func: map[string]FuncLookup{
 					"scratch": FuncLookup{
 						Params:  []*parser.Field{},
@@ -195,7 +195,7 @@ var (
 					},
 				},
 			},
-			"group": LookupByType{
+			"group": LookupByKind{
 				Func: map[string]FuncLookup{
 					"parallel": FuncLookup{
 						Params: []*parser.Field{
@@ -205,7 +205,7 @@ var (
 					},
 				},
 			},
-			"option::copy": LookupByType{
+			"option::copy": LookupByKind{
 				Func: map[string]FuncLookup{
 					"followSymlinks": FuncLookup{
 						Params:  []*parser.Field{},
@@ -251,7 +251,7 @@ var (
 					},
 				},
 			},
-			"option::frontend": LookupByType{
+			"option::frontend": LookupByKind{
 				Func: map[string]FuncLookup{
 					"input": FuncLookup{
 						Params: []*parser.Field{
@@ -269,7 +269,7 @@ var (
 					},
 				},
 			},
-			"option::git": LookupByType{
+			"option::git": LookupByKind{
 				Func: map[string]FuncLookup{
 					"keepGitDir": FuncLookup{
 						Params:  []*parser.Field{},
@@ -277,7 +277,7 @@ var (
 					},
 				},
 			},
-			"option::http": LookupByType{
+			"option::http": LookupByKind{
 				Func: map[string]FuncLookup{
 					"checksum": FuncLookup{
 						Params: []*parser.Field{
@@ -299,7 +299,7 @@ var (
 					},
 				},
 			},
-			"option::image": LookupByType{
+			"option::image": LookupByKind{
 				Func: map[string]FuncLookup{
 					"resolve": FuncLookup{
 						Params:  []*parser.Field{},
@@ -307,7 +307,7 @@ var (
 					},
 				},
 			},
-			"option::local": LookupByType{
+			"option::local": LookupByKind{
 				Func: map[string]FuncLookup{
 					"includePatterns": FuncLookup{
 						Params: []*parser.Field{
@@ -329,7 +329,7 @@ var (
 					},
 				},
 			},
-			"option::localRun": LookupByType{
+			"option::localRun": LookupByKind{
 				Func: map[string]FuncLookup{
 					"ignoreError": FuncLookup{
 						Params:  []*parser.Field{},
@@ -349,7 +349,7 @@ var (
 					},
 				},
 			},
-			"option::mkdir": LookupByType{
+			"option::mkdir": LookupByKind{
 				Func: map[string]FuncLookup{
 					"createParents": FuncLookup{
 						Params:  []*parser.Field{},
@@ -369,7 +369,7 @@ var (
 					},
 				},
 			},
-			"option::mkfile": LookupByType{
+			"option::mkfile": LookupByKind{
 				Func: map[string]FuncLookup{
 					"chown": FuncLookup{
 						Params: []*parser.Field{
@@ -385,7 +385,7 @@ var (
 					},
 				},
 			},
-			"option::mount": LookupByType{
+			"option::mount": LookupByKind{
 				Func: map[string]FuncLookup{
 					"readonly": FuncLookup{
 						Params:  []*parser.Field{},
@@ -410,7 +410,7 @@ var (
 					},
 				},
 			},
-			"option::rm": LookupByType{
+			"option::rm": LookupByKind{
 				Func: map[string]FuncLookup{
 					"allowNotFound": FuncLookup{
 						Params:  []*parser.Field{},
@@ -422,7 +422,7 @@ var (
 					},
 				},
 			},
-			"option::run": LookupByType{
+			"option::run": LookupByKind{
 				Func: map[string]FuncLookup{
 					"readonlyRootfs": FuncLookup{
 						Params:  []*parser.Field{},
@@ -503,7 +503,7 @@ var (
 					},
 				},
 			},
-			"option::secret": LookupByType{
+			"option::secret": LookupByKind{
 				Func: map[string]FuncLookup{
 					"uid": FuncLookup{
 						Params: []*parser.Field{
@@ -537,7 +537,7 @@ var (
 					},
 				},
 			},
-			"option::ssh": LookupByType{
+			"option::ssh": LookupByKind{
 				Func: map[string]FuncLookup{
 					"target": FuncLookup{
 						Params: []*parser.Field{
@@ -571,7 +571,7 @@ var (
 					},
 				},
 			},
-			"option::template": LookupByType{
+			"option::template": LookupByKind{
 				Func: map[string]FuncLookup{
 					"stringField": FuncLookup{
 						Params: []*parser.Field{
@@ -582,7 +582,7 @@ var (
 					},
 				},
 			},
-			parser.Str: LookupByType{
+			parser.Str: LookupByKind{
 				Func: map[string]FuncLookup{
 					"format": FuncLookup{
 						Params: []*parser.Field{

--- a/checker/builtin.go
+++ b/checker/builtin.go
@@ -12,14 +12,14 @@ var Builtin = NewBuiltinScope(builtin.Lookup)
 // apply to builtins.
 type BuiltinDecl struct {
 	*parser.Ident
-	Func map[parser.ObjType]*parser.FuncDecl
+	Func map[parser.Kind]*parser.FuncDecl
 }
 
 // NewBuiltinScope returns a new Scope containing synthetic FuncDecl Objects for
 // builtins.
 func NewBuiltinScope(builtins builtin.BuiltinLookup) *parser.Scope {
 	scope := parser.NewScope(nil, nil)
-	for typ, entries := range builtins.ByType {
+	for kind, entries := range builtins.ByKind {
 		for name, fn := range entries.Func {
 			obj := scope.Lookup(name)
 			if obj == nil {
@@ -30,7 +30,7 @@ func NewBuiltinScope(builtins builtin.BuiltinLookup) *parser.Scope {
 					Ident: ident,
 					Node: &BuiltinDecl{
 						Ident: ident,
-						Func:  make(map[parser.ObjType]*parser.FuncDecl),
+						Func:  make(map[parser.Kind]*parser.FuncDecl),
 					},
 				}
 			}
@@ -39,10 +39,10 @@ func NewBuiltinScope(builtins builtin.BuiltinLookup) *parser.Scope {
 				panic("implementation error")
 			}
 
-			fun := parser.NewFuncDecl(typ, name, fn.Params, fn.Effects).Func
+			fun := parser.NewFuncDecl(kind, name, fn.Params, fn.Effects).Func
 			fun.Pos.Filename = "<builtin>"      // for errors attached to func
 			fun.Name.Pos.Filename = "<builtin>" // for errors attached to Name
-			decl.Func[typ] = fun
+			decl.Func[kind] = fun
 			scope.Insert(obj)
 		}
 	}

--- a/checker/errors.go
+++ b/checker/errors.go
@@ -112,8 +112,8 @@ func (e ErrFuncArg) Error() string {
 
 type ErrWrongArgType struct {
 	Pos      lexer.Position
-	Expected parser.ObjType
-	Found    parser.ObjType
+	Expected parser.Kind
+	Found    parser.Kind
 }
 
 func (e ErrWrongArgType) Error() string {
@@ -122,7 +122,7 @@ func (e ErrWrongArgType) Error() string {
 
 type ErrWrongBuiltinType struct {
 	Pos      lexer.Position
-	Expected parser.ObjType
+	Expected parser.Kind
 	Builtin  *BuiltinDecl
 }
 

--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -31,8 +31,8 @@ type GroupChain func([]solver.Request) ([]solver.Request, error)
 
 type StringChain func(string) (string, error)
 
-func (cg *CodeGen) EmitChainStmt(ctx context.Context, scope *parser.Scope, typ parser.ObjType, call *parser.CallStmt, chainStart interface{}) (func(v interface{}) (interface{}, error), error) {
-	switch typ {
+func (cg *CodeGen) EmitChainStmt(ctx context.Context, scope *parser.Scope, kind parser.Kind, call *parser.CallStmt, chainStart interface{}) (func(v interface{}) (interface{}, error), error) {
+	switch kind {
 	case parser.Filesystem:
 		chain, err := cg.EmitFilesystemChainStmt(ctx, scope, call.Func, call.Args, call.WithOpt, call.Binds, chainStart)
 		if err != nil {

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -129,15 +129,15 @@ func (cg *CodeGen) Generate(ctx context.Context, mod *parser.Module, targets []T
 		}
 
 		var (
-			v   interface{}
-			typ *parser.Type
+			v    interface{}
+			kind *parser.Type
 		)
 		switch obj.Kind {
 		case parser.DeclKind:
 			switch n := obj.Node.(type) {
 			case *parser.FuncDecl:
-				typ = n.Type
-				if typ.Primary() != parser.Group && typ.Primary() != parser.Filesystem {
+				kind = n.Type
+				if kind.Primary() != parser.Group && kind.Primary() != parser.Filesystem {
 					return nil, checker.ErrInvalidTarget{Node: n, Target: target.Name}
 				}
 
@@ -147,8 +147,8 @@ func (cg *CodeGen) Generate(ctx context.Context, mod *parser.Module, targets []T
 				}
 			case *parser.BindClause:
 				b := n.TargetBinding(target.Name)
-				typ = b.Field.Type
-				if typ.Primary() != parser.Group && typ.Primary() != parser.Filesystem {
+				kind = b.Field.Type
+				if kind.Primary() != parser.Group && kind.Primary() != parser.Filesystem {
 					return nil, checker.ErrInvalidTarget{Node: n, Target: target.Name}
 				}
 
@@ -163,7 +163,7 @@ func (cg *CodeGen) Generate(ctx context.Context, mod *parser.Module, targets []T
 
 		var request solver.Request
 
-		switch typ.Primary() {
+		switch kind.Primary() {
 		case parser.Group:
 			var ok bool
 			request, ok = v.(solver.Request)
@@ -275,9 +275,9 @@ func isBreakpoint(call *parser.CallStmt) bool {
 	return call.Func.Name() == "breakpoint"
 }
 
-func (cg *CodeGen) EmitBlock(ctx context.Context, scope *parser.Scope, typ parser.ObjType, stmts []*parser.Stmt, chainStart interface{}) (interface{}, error) {
+func (cg *CodeGen) EmitBlock(ctx context.Context, scope *parser.Scope, kind parser.Kind, stmts []*parser.Stmt, chainStart interface{}) (interface{}, error) {
 	var v = chainStart
-	switch typ {
+	switch kind {
 	case parser.Filesystem:
 		if _, ok := v.(llb.State); v == nil || !ok {
 			v = llb.Scratch()
@@ -309,7 +309,7 @@ func (cg *CodeGen) EmitBlock(ctx context.Context, scope *parser.Scope, typ parse
 			return v, err
 		}
 
-		chain, err := cg.EmitChainStmt(ctx, scope, typ, call, v)
+		chain, err := cg.EmitChainStmt(ctx, scope, kind, call, v)
 		if err != nil {
 			return v, err
 		}

--- a/codegen/debug.go
+++ b/codegen/debug.go
@@ -345,8 +345,8 @@ func NewDebugger(c *client.Client, w io.Writer, r *bufio.Reader, fbs map[string]
 				case "stepout":
 					fmt.Fprintf(w, "unimplemented\n")
 				case "types":
-					for _, typ := range report.Types {
-						fmt.Fprintf(w, "%s\n", typ)
+					for _, kind := range report.Kinds {
+						fmt.Fprintf(w, "%s\n", kind)
 					}
 				case "whatis":
 					fmt.Fprintf(w, "unimplemented\n")

--- a/codegen/decl.go
+++ b/codegen/decl.go
@@ -71,8 +71,8 @@ func (cg *CodeGen) ParameterizedScope(ctx context.Context, scope *parser.Scope, 
 			err  error
 		)
 
-		typ := field.Type.Primary()
-		switch typ {
+		kind := field.Type.Primary()
+		switch kind {
 		case parser.Str:
 			var v string
 			v, err = cg.EmitStringExpr(ctx, scope, args[i])

--- a/gen/documentation.go
+++ b/gen/documentation.go
@@ -42,7 +42,7 @@ func GenerateDocumentation(r io.Reader) (*Documentation, error) {
 	}
 
 	var (
-		funcsByType   = make(map[string][]*Func)
+		funcsByKind   = make(map[string][]*Func)
 		optionsByFunc = make(map[string][]*Func)
 	)
 
@@ -54,7 +54,7 @@ func GenerateDocumentation(r io.Reader) (*Documentation, error) {
 
 		var (
 			group  *doxygen.Group
-			typ    string
+			kind   string
 			name   string
 			fields []Field
 		)
@@ -73,7 +73,7 @@ func GenerateDocumentation(r io.Reader) (*Documentation, error) {
 		}
 
 		if fun.Type != nil {
-			typ = fun.Type.String()
+			kind = fun.Type.String()
 		}
 
 		if fun.Name != nil {
@@ -116,7 +116,7 @@ func GenerateDocumentation(r io.Reader) (*Documentation, error) {
 		}
 
 		funcDoc := &Func{
-			Type:   typ,
+			Type:   kind,
 			Name:   name,
 			Params: fields,
 		}
@@ -129,10 +129,10 @@ func GenerateDocumentation(r io.Reader) (*Documentation, error) {
 			subtype := string(fun.Type.Secondary())
 			optionsByFunc[subtype] = append(optionsByFunc[subtype], funcDoc)
 		}
-		funcsByType[typ] = append(funcsByType[typ], funcDoc)
+		funcsByKind[kind] = append(funcsByKind[kind], funcDoc)
 	}
 
-	for _, funcs := range funcsByType {
+	for _, funcs := range funcsByKind {
 		for _, fun := range funcs {
 			options, ok := optionsByFunc[fun.Name]
 			if !ok {
@@ -145,8 +145,8 @@ func GenerateDocumentation(r io.Reader) (*Documentation, error) {
 
 	var doc Documentation
 
-	for _, typ := range []string{"fs", "string"} {
-		funcs := funcsByType[typ]
+	for _, kind := range []string{"fs", "string"} {
+		funcs := funcsByKind[kind]
 		for _, fun := range funcs {
 			fun := fun
 			sort.SliceStable(fun.Options, func(i, j int) bool {
@@ -159,7 +159,7 @@ func GenerateDocumentation(r io.Reader) (*Documentation, error) {
 		})
 
 		builtin := Builtin{
-			Type: typ,
+			Type: kind,
 		}
 
 		builtin.Funcs = append(builtin.Funcs, funcs...)

--- a/langserver/server.go
+++ b/langserver/server.go
@@ -262,9 +262,9 @@ func highlightBlock(lines map[int]lsp.SemanticHighlightingTokens, block *parser.
 			switch {
 			case call.Func.Ident != nil:
 				ident = call.Func.Ident
-				lookupByType, ok := builtin.Lookup.ByType[block.ObjType]
+				lookupByKind, ok := builtin.Lookup.ByKind[block.Kind]
 				if ok {
-					_, ok = lookupByType.Func[ident.Name]
+					_, ok = lookupByKind.Func[ident.Name]
 					if !ok {
 						highlightNode(lines, ident, Variable)
 					}
@@ -625,12 +625,12 @@ func (ls *LangServer) textDocumentHoverHandler(ctx context.Context, params lsp.T
 			},
 		},
 		func(block *parser.BlockStmt, ident *parser.Ident) {
-			lookupByType, ok := builtin.Lookup.ByType[block.ObjType]
+			lookupByKind, ok := builtin.Lookup.ByKind[block.Kind]
 			if !ok {
 				return
 			}
 
-			fun, ok := lookupByType.Func[ident.Name]
+			fun, ok := lookupByKind.Func[ident.Name]
 			if !ok {
 				return
 			}

--- a/parser/cst.go
+++ b/parser/cst.go
@@ -260,9 +260,9 @@ type FuncDecl struct {
 	Body        *BlockStmt     `parser:"( @@ )?"`
 }
 
-func NewFuncDecl(typ ObjType, name string, params []*Field, effects []*Field, stmts ...*Stmt) *Decl {
+func NewFuncDecl(kind Kind, name string, params []*Field, effects []*Field, stmts ...*Stmt) *Decl {
 	fun := &FuncDecl{
-		Type:        NewType(typ),
+		Type:        NewType(kind),
 		Name:        NewIdent(name),
 		Params:      NewFieldList(params...),
 		Body:        NewBlockStmt(stmts...),
@@ -332,9 +332,9 @@ type Field struct {
 	Name     *Ident    `parser:"@@"`
 }
 
-func NewField(typ ObjType, name string, variadic bool) *Field {
+func NewField(kind Kind, name string, variadic bool) *Field {
 	f := &Field{
-		Type: NewType(typ),
+		Type: NewType(kind),
 		Name: NewIdent(name),
 	}
 	if variadic {
@@ -401,53 +401,53 @@ func (e *Expr) IdentNode() *Ident {
 
 // Type represents an object type.
 type Type struct {
-	Pos     lexer.Position
-	ObjType ObjType `parser:"@Type"`
+	Pos  lexer.Position
+	Kind Kind `parser:"@Type"`
 }
 
-func NewType(typ ObjType) *Type {
-	return &Type{ObjType: typ}
+func NewType(kind Kind) *Type {
+	return &Type{Kind: kind}
 }
 
 func (t *Type) Position() lexer.Position { return t.Pos }
-func (t *Type) End() lexer.Position      { return shiftPosition(t.Pos, len(string(t.ObjType)), 0) }
+func (t *Type) End() lexer.Position      { return shiftPosition(t.Pos, len(string(t.Kind)), 0) }
 
-func (t *Type) Primary() ObjType {
-	parts := typeParts(t.ObjType)
-	return ObjType(parts[0])
+func (t *Type) Primary() Kind {
+	parts := typeParts(t.Kind)
+	return Kind(parts[0])
 }
 
-func (t *Type) Secondary() ObjType {
-	parts := typeParts(t.ObjType)
+func (t *Type) Secondary() Kind {
+	parts := typeParts(t.Kind)
 	if len(parts) == 1 {
 		return None
 	}
-	return ObjType(parts[1])
+	return Kind(parts[1])
 }
 
-func typeParts(typ ObjType) []string {
-	return strings.Split(string(typ), "::")
+func typeParts(kind Kind) []string {
+	return strings.Split(string(kind), "::")
 }
 
-// Equals returns whether type equals another ObjType.
-func (t *Type) Equals(typ ObjType) bool {
+// Equals returns whether type equals another Kind.
+func (t *Type) Equals(kind Kind) bool {
 	if t.Primary() == Option && t.Secondary() == None {
-		parts := typeParts(typ)
-		return ObjType(parts[0]) == Option
+		parts := typeParts(kind)
+		return Kind(parts[0]) == Option
 	}
-	return t.ObjType == typ
+	return t.Kind == kind
 }
 
-type ObjType string
+type Kind string
 
 const (
-	None       ObjType = ""
-	Str        ObjType = "string"
-	Int        ObjType = "int"
-	Bool       ObjType = "bool"
-	Filesystem ObjType = "fs"
-	Option     ObjType = "option"
-	Group      ObjType = "group"
+	None       Kind = ""
+	Str        Kind = "string"
+	Int        Kind = "int"
+	Bool       Kind = "bool"
+	Filesystem Kind = "fs"
+	Option     Kind = "option"
+	Group      Kind = "group"
 )
 
 // Ident represents an identifier.
@@ -657,8 +657,8 @@ func (l *NumericLit) Capture(tokens []string) error {
 	return err
 }
 
-// ObjType returns the type of the basic literal.
-func (l *BasicLit) ObjType() ObjType {
+// Kind returns the type of the basic literal.
+func (l *BasicLit) Kind() Kind {
 	switch {
 	case l.Str != nil, l.HereDoc != nil:
 		return Str
@@ -714,18 +714,18 @@ type FuncLit struct {
 	Body *BlockStmt `parser:"@@"`
 }
 
-func NewFuncLit(typ ObjType, stmts ...*Stmt) *FuncLit {
+func NewFuncLit(kind Kind, stmts ...*Stmt) *FuncLit {
 	return &FuncLit{
-		Type: NewType(typ),
+		Type: NewType(kind),
 		Body: &BlockStmt{
 			List: stmts,
 		},
 	}
 }
 
-func NewFuncLitExpr(typ ObjType, stmts ...*Stmt) *Expr {
+func NewFuncLitExpr(kind Kind, stmts ...*Stmt) *Expr {
 	return &Expr{
-		FuncLit: NewFuncLit(typ, stmts...),
+		FuncLit: NewFuncLit(kind, stmts...),
 	}
 }
 
@@ -946,7 +946,7 @@ type BlockStmt struct {
 	List       []*Stmt     `parser:"( @@ )*"`
 	CloseBrace *CloseBrace `parser:"@@"`
 	Scope      *Scope
-	ObjType    ObjType
+	Kind       Kind
 	Closure    *FuncDecl
 }
 

--- a/parser/unparse.go
+++ b/parser/unparse.go
@@ -168,7 +168,7 @@ func (v *Variadic) String() string {
 }
 
 func (t *Type) String() string {
-	return string(t.ObjType)
+	return string(t.Kind)
 }
 
 func (e *Expr) String() string {

--- a/report/report.go
+++ b/report/report.go
@@ -14,7 +14,7 @@ var (
 	Sources = []string{"scratch", "image", "http", "git", "local", "frontend"}
 	Ops     = []string{"shell", "run", "env", "dir", "user", "entrypoint", "mkdir", "mkfile", "rm", "copy"}
 	Debugs  = []string{"breakpoint"}
-	Types   = []string{"string", "int", "bool", "fs", "option"}
+	Kinds   = []string{"string", "int", "bool", "fs", "option"}
 
 	CommonOptions   = []string{"no-cache"}
 	ImageOptions    = []string{"resolve"}
@@ -38,11 +38,11 @@ var (
 	Options          = flatMap(ImageOptions, HTTPOptions, GitOptions, RunOptions, SSHOptions, SecretOptions, MountOptions, MkdirOptions, MkfileOptions, RmOptions, CopyOptions)
 	Enums            = flatMap(NetworkModes, SecurityModes, CacheSharingModes)
 	Fields           = flatMap(Sources, Ops, Options)
-	Keywords         = flatMap(Types, Sources, Fields, Enums)
-	ReservedKeywords = flatMap(Types, []string{"with"})
+	Keywords         = flatMap(Kinds, Sources, Fields, Enums)
+	ReservedKeywords = flatMap(Kinds, []string{"with"})
 
 	KeywordsWithOptions = []string{"image", "http", "git", "run", "ssh", "secret", "mount", "mkdir", "mkfile", "rm", "copy"}
-	KeywordsWithBlocks  = flatMap(Types, KeywordsWithOptions)
+	KeywordsWithBlocks  = flatMap(Kinds, KeywordsWithOptions)
 
 	KeywordsByName = map[string][]string{
 		"fs":       Ops,

--- a/report/syntax.go
+++ b/report/syntax.go
@@ -28,7 +28,7 @@ func NewSyntaxError(color aurora.Aurora, fb *parser.FileBuffer, lex *lexer.Peeki
 		// panic(fmt.Sprintf("%s:%d:%d: expected %q unexpected %q", unexpected.Pos.Filename, unexpected.Pos.Line, unexpected.Pos.Column, expected, unexpected))
 		switch expected {
 		case "":
-			if !Contains(Types, unexpected.Value) {
+			if !Contains(Kinds, unexpected.Value) {
 				// Invalid function type.
 				group, err = errFunc(color, fb, lex, unexpected)
 			} else {
@@ -82,8 +82,8 @@ func errFunc(color aurora.Aurora, fb *parser.FileBuffer, _ *lexer.PeekingLexer, 
 		return group, err
 	}
 
-	suggestion, _ := getSuggestion(color, Types, token.Value)
-	help := helpValidKeywords(color, Types, "type")
+	suggestion, _ := getSuggestion(color, Kinds, token.Value)
+	help := helpValidKeywords(color, Kinds, "type")
 
 	return AnnotationGroup{
 		Pos: token.Pos,
@@ -304,7 +304,7 @@ func errArgType(color aurora.Aurora, fb *parser.FileBuffer, lex *lexer.PeekingLe
 		return group, err
 	}
 
-	suggestion, _ := getSuggestion(color, Types, endToken.Value)
+	suggestion, _ := getSuggestion(color, Kinds, endToken.Value)
 
 	return AnnotationGroup{
 		Pos: endToken.Pos,
@@ -325,7 +325,7 @@ func errArgType(color aurora.Aurora, fb *parser.FileBuffer, lex *lexer.PeekingLe
 					suggestion),
 			},
 		},
-		Help: helpValidKeywords(color, Types, "argument type"),
+		Help: helpValidKeywords(color, Kinds, "argument type"),
 	}, nil
 }
 


### PR DESCRIPTION
Differentiating `ObjType` and `Type` is confusing, and we typically named `ObjType` and `Type` variables both as `typ` because `type` is a keyword in golang. Using `Kind` keeps this simple.