### PR TITLE
use the image spec returned from the remote frontend

### DIFF
--- a/codegen/chain.go
+++ b/codegen/chain.go
@@ -350,6 +350,10 @@ func (cg *CodeGen) EmitFilesystemBuiltinChainStmt(ctx context.Context, scope *pa
 							st, err = ref.ToState()
 						}
 
+						// apply image from the frontend into the current state
+						if spec, ok := res.Metadata[keyContainerImageConfig]; ok {
+							st, err = cg.stateFromImageSpec(st, spec)
+						}
 						return res, err
 					})
 				})


### PR DESCRIPTION
This PR changes `frontend` to modify the current `llb.State` with the returned image spec. 

For example, running this hlb file:

```
fs dockerfile() {
	scratch
	mkfile "/Dockerfile" 0o666 string {
	    template <<-EOF
            FROM alpine:latest
            LABEL dockerfile-label="value"
            ENV foo=bar

	    EOF
	}
}

fs build() {
	label "early-label" "some value"
	frontend "docker/dockerfile" with option {
		input "context" fs { scratch; }
		input "dockerfile" dockerfile
	}
	label "late-label" "some other value"
}

fs default() {
	build
	dockerLoad "my/image"
}
```

should produce a local image with the following metadata:
```
{
  "Hostname": "",
  "Domainname": "",
  "User": "",
  "AttachStdin": false,
  "AttachStdout": false,
  "AttachStderr": false,
  "Tty": false,
  "OpenStdin": false,
  "StdinOnce": false,
  "Env": [
    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
    "foo=bar"
  ],
  "Cmd": [
    "/bin/sh"
  ],
  "Image": "",
  "Volumes": null,
  "WorkingDir": "/",
  "Entrypoint": null,
  "OnBuild": null,
  "Labels": {
    "dockerfile-label": "value",
    "early-label": "some value",
    "late-label": "some other value"
  }
}
```

Note that `early-label` and `late-label` are both preserved from HLB, and the `dockerfile-label` is preserved from the Dockerfile and merged into the `cg.image` value. The same holds for `Env` and `WorkingDir`, which are held on the `llb.State`.