### PR TITLE
Fix secret missing path resolution

### DIFF
--- a/codegen/builtin_option.go
+++ b/codegen/builtin_option.go
@@ -648,6 +648,11 @@ func (s Secret) Call(ctx context.Context, cln *client.Client, ret Register, opts
 		}
 	}
 
+	localPath, err = parser.ResolvePath(ModuleDir(ctx), localPath)
+	if err != nil {
+		return err
+	}
+
 	localFiles, err := llbutil.FilterLocalFiles(localPath, includePatterns, excludePatterns)
 	if err != nil {
 		return err


### PR DESCRIPTION
After refactoring to new `codegen`, the `secret` builtin was missing path resolution.