### PR TITLE
Fix regression for image config not persisted from image resolve

### DIFF
--- a/codegen/builtin_option.go
+++ b/codegen/builtin_option.go
@@ -14,7 +14,6 @@ import (
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
-	"github.com/moby/buildkit/client/llb/imagemetaresolver"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"github.com/moby/buildkit/solver/pb"
@@ -32,16 +31,7 @@ import (
 type Resolve struct{}
 
 func (ir Resolve) Call(ctx context.Context, cln *client.Client, ret Register, opts Option) error {
-	retOpts, err := ret.Option()
-	if err != nil {
-		return err
-	}
-
-	return ret.Set(append(retOpts, llb.WithMetaResolver(
-		imagemetaresolver.New(
-			imagemetaresolver.WithDefaultPlatform(&specs.Platform{OS: "linux", Architecture: "amd64"}),
-		),
-	)))
+	return nil
 }
 
 type Checksum struct{}

--- a/pkg/imageutil/buffered_resolver.go
+++ b/pkg/imageutil/buffered_resolver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/moby/buildkit/util/imageutil"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 )
 
 // BufferedImageResolver is an image resolver with a public Buffer. It implements the
@@ -106,7 +107,7 @@ func (bir *BufferedImageResolver) MatchDefaultPlatform() platforms.MatchComparer
 func (bir *BufferedImageResolver) ResolveDescriptor(ctx context.Context, ref string) (specs.Descriptor, error) {
 	r, err := reference.Parse(ref)
 	if err != nil {
-		return specs.Descriptor{}, err
+		return specs.Descriptor{}, errors.Wrapf(err, "cannot parse reference %q", ref)
 	}
 
 	desc, _ := bir.DigestDescriptor(ctx, r.Digest())
@@ -116,7 +117,7 @@ func (bir *BufferedImageResolver) ResolveDescriptor(ctx context.Context, ref str
 		var err error
 		_, desc, err = bir.resolver.Resolve(ctx, r.String())
 		if err != nil {
-			return desc, err
+			return desc, errors.Wrapf(err, "cannot resolve %q", r)
 		}
 	}
 


### PR DESCRIPTION
- Resolve is now no-op as planned. Deprecation for `resolve` should show up in `linter` from: https://github.com/openllb/hlb/pull/181
- Entire image config kept from resolve config into new `codegen.Filesystem`, since `llb.WithMetaResolver` throws away a lot of the config.