### PR TITLE
Allow building and importing Dockerfiles directly into HLB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine AS foo

--- a/Dockerfile2
+++ b/Dockerfile2
@@ -1,0 +1,2 @@
+FROM busybox AS bar
+RUN echo foo > /foo

--- a/codegen/builtin_option.go
+++ b/codegen/builtin_option.go
@@ -146,6 +146,18 @@ func (fo FrontendOpt) Call(ctx context.Context, cln *client.Client, ret Register
 	return ret.Set(append(retOpts, llbutil.FrontendOpt(key, value)))
 }
 
+type DockerfileInfo struct {
+	Target string
+}
+
+type DockerfileOption func(*DockerfileInfo)
+
+func WithDockerfileTarget(target string) DockerfileOption {
+	return func(info *DockerfileInfo) {
+		info.Target = target
+	}
+}
+
 type CreateParents struct{}
 
 func (cp CreateParents) Call(ctx context.Context, cln *client.Client, ret Register, opts Option) error {

--- a/foo.hlb
+++ b/foo.hlb
@@ -1,0 +1,8 @@
+import dockerfile from "./Dockerfile"
+import dockerfile2 from "./Dockerfile2"
+
+fs default() {
+	dockerfile.foo
+	copy dockerfile2.bar "/foo" "/"
+	dockerLoad "foo"
+}

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,7 @@ github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQ
 github.com/moby/buildkit v0.7.0/go.mod h1:zOhLO1TiQepuSfzoNDQ542IGJQy0CHr79T4MOJvaewY=
 github.com/moby/buildkit v0.7.1-0.20200806195445-545532ab0e75 h1:ZdGywsnFmdB9lRG9c5V8Txk6I313pzLjK+wETrSOkHk=
 github.com/moby/buildkit v0.7.1-0.20200806195445-545532ab0e75/go.mod h1:qkn93TsVJHfrNoj7fxQuhVyl8HjvLPpBlpRIeYDi9QI=
+github.com/moby/buildkit v0.7.2 h1:wp4R0QMXSqwjTJKhhWlJNOCSQ/OVPnsCf3N8rs09+vQ=
 github.com/moby/sys/mountinfo v0.1.3/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -3,6 +3,7 @@ package linter
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	"github.com/openllb/hlb/checker"
 	"github.com/openllb/hlb/codegen"
@@ -97,6 +98,10 @@ func (l *Linter) LintRecursive(mod *parser.Module, expr *parser.Expr) error {
 	path, err := ret.String()
 	if err != nil {
 		return err
+	}
+
+	if filepath.Ext(path) != "hlb" {
+		return nil
 	}
 
 	f, err := os.Open(path)

--- a/parse.go
+++ b/parse.go
@@ -3,6 +3,7 @@ package hlb
 import (
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/alecthomas/participle/lexer"
 	"github.com/logrusorgru/aurora"
@@ -59,12 +60,16 @@ func Parse(r io.Reader, opts ...ParseOption) (*parser.Module, *parser.FileBuffer
 
 	name := lexer.NameOfReader(r)
 	if name == "" {
-		name = "<stdin>"
+		name = "/dev/stdin.hlb"
 	}
 	r = &parser.NewlinedReader{Reader: r}
 
 	fb := parser.NewFileBuffer(name)
 	r = io.TeeReader(r, fb)
+
+	if filepath.Ext(name) != ".hlb" {
+		return parser.ParseDockerfile(r)
+	}
 
 	lex, err := parser.Parser.Lexer().Lex(&parser.NamedReader{
 		Reader: r,

--- a/parser/cst.go
+++ b/parser/cst.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alecthomas/participle"
 	"github.com/alecthomas/participle/lexer"
 	"github.com/alecthomas/participle/lexer/stateful"
+	dfinstructions "github.com/moby/buildkit/frontend/dockerfile/instructions"
 )
 
 var (
@@ -154,11 +155,12 @@ type Module struct {
 // Decl represents a declaration node.
 type Decl struct {
 	Mixin
-	Import   *ImportDecl   `parser:"( @@"`
-	Export   *ExportDecl   `parser:"| @@"`
-	Func     *FuncDecl     `parser:"| @@"`
-	Newline  *Newline      `parser:"| @@"`
-	Comments *CommentGroup `parser:"| @@ )"`
+	Dockerfile *DockerfileDecl
+	Import     *ImportDecl   `parser:"( @@"`
+	Export     *ExportDecl   `parser:"| @@"`
+	Func       *FuncDecl     `parser:"| @@"`
+	Newline    *Newline      `parser:"| @@"`
+	Comments   *CommentGroup `parser:"| @@ )"`
 }
 
 // ImportDecl represents an import declaration.
@@ -194,6 +196,17 @@ type ExportDecl struct {
 type Export struct {
 	Mixin
 	Text string `parser:"@'export'"`
+}
+
+type DockerfileDecl struct {
+	Mixin
+	Stage   dfinstructions.Stage
+	Target  string
+	Content []byte
+}
+
+func (d *DockerfileDecl) String() string {
+	return string(d.Content)
 }
 
 // BuiltinDecl is a synthetic declaration representing a builtin name.

--- a/parser/dockerfile.go
+++ b/parser/dockerfile.go
@@ -1,0 +1,77 @@
+package parser
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/alecthomas/participle/lexer"
+	dfinstructions "github.com/moby/buildkit/frontend/dockerfile/instructions"
+	dfparser "github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+func DFRangeToMixin(filename string, loc dfparser.Range) Mixin {
+	return Mixin{
+		Pos:    DFPositionToLexerPosition(filename, loc.Start),
+		EndPos: DFPositionToLexerPosition(filename, loc.End),
+	}
+}
+
+func DFPositionToLexerPosition(filename string, pos dfparser.Position) lexer.Position {
+	return lexer.Position{
+		Filename: filename,
+		Line:     pos.Line,
+		Column:   pos.Character,
+	}
+}
+
+func ParseDockerfile(r io.Reader) (*Module, *FileBuffer, error) {
+	name := lexer.NameOfReader(r)
+	if name == "" {
+		name = "<stdin>"
+	}
+
+	fb := NewFileBuffer(name)
+	r = io.TeeReader(r, fb)
+
+	df, err := dfparser.Parse(r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stages, _, err := dfinstructions.Parse(df.AST)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mod := &Module{
+		Mixin: Mixin{
+			Pos: lexer.Position{
+				Filename: name,
+			},
+		},
+	}
+	mod.Scope = NewScope(mod, nil)
+
+	for i, stage := range stages {
+		target := stage.Name
+		if target == "" {
+			target = fmt.Sprintf("stage-%d", i)
+		}
+
+		dd := &DockerfileDecl{
+			Stage: stage,
+			Target:  target,
+			Content: fb.Bytes(),
+		}
+		if len(df.AST.Location()) > 0 {
+			dd.Mixin = DFRangeToMixin(name, df.AST.Location()[0])
+		}
+		mod.Decls = append(mod.Decls, &Decl{
+			Mixin:      dd.Mixin,
+			Dockerfile: dd,
+		})
+
+	}
+
+	return mod, fb, nil
+}

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -20,16 +20,19 @@ func Parse(r io.Reader) (*Module, *FileBuffer, error) {
 	mod := &Module{}
 	lex, err := Parser.Lexer().Lex(&NamedReader{r, name})
 	if err != nil {
+		panic(err)
 		return mod, fb, err
 	}
 
 	peeker, err := lexer.Upgrade(lex)
 	if err != nil {
+		panic(err)
 		return mod, fb, err
 	}
 
 	err = Parser.ParseFromLexer(peeker, mod)
 	if err != nil {
+		panic(err)
 		return mod, fb, err
 	}
 	AssignDocStrings(mod)

--- a/parser/walk.go
+++ b/parser/walk.go
@@ -55,6 +55,8 @@ func (w *walker) walk(node Node, v Visitor) {
 		w.walkDeclList(n.Decls, v)
 	case *Decl:
 		switch {
+		case n.Dockerfile != nil:
+			w.walk(n.Dockerfile, v)
 		case n.Import != nil:
 			w.walk(n.Import, v)
 		case n.Export != nil:


### PR DESCRIPTION
This is only an experiment, the idea is the further bridge the gap between Dockerfiles and HLBs, allowing for users to incrementally migrate or leverage HLB without rewriting Dockerfiles.

## Running a stage in a Dockerfile with `hlb run`
```sh
❯ cat Dockerfile
FROM alpine AS foo

❯ hlb run -t foo Dockerfile
[+] Building 0.3s (2/2) FINISHED
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                      0.2s
 => CACHED [1/1] FROM docker.io/library/alpine@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321                                                0.0s
 => => resolve docker.io/library/alpine@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321                                                       0.0s
```

## Importing a dockerfile and referencing a stage as if it was an exported function of a HLB module.
```sh
❯ cat foo.hlb
import dockerfile from "./Dockerfile"

fs default() {
	dockerfile.foo
}

❯ hlb run foo.hlb
[+] Building 0.2s (2/2) FINISHED
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                      0.1s
 => CACHED [1/1] FROM docker.io/library/alpine@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321                                                0.0s
 => => resolve docker.io/library/alpine@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321                                                       0.0s
```

## Multi-stage docker build with multiple dockerfiles
```hlb
import dockerfile from "./Dockerfile"
import dockerfile2 from "./Dockerfile2"

fs default() {
	dockerfile.foo
	copy dockerfile2.bar "/foo" "/"
}
```