### PR TITLE
Fix relative path resolution for imports

### DIFF
--- a/cmd/hlb/command/lint.go
+++ b/cmd/hlb/command/lint.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/moby/buildkit/util/appcontext"
 	"github.com/openllb/hlb"
 	"github.com/openllb/hlb/checker"
 	"github.com/openllb/hlb/linter"
@@ -37,7 +38,8 @@ var lintCommand = &cli.Command{
 			return err
 		}
 
-		err = linter.Lint(mod, linter.WithRecursive())
+		ctx := appcontext.Context()
+		err = linter.Lint(ctx, mod, linter.WithRecursive())
 		if err != nil {
 			if lintErr, ok := err.(linter.ErrLint); ok {
 				if !c.Bool("fix") {

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -797,6 +797,7 @@ func TestCodeGen(t *testing.T) {
 	}} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := codegen.WithSessionID(context.Background(), identity.NewID())
 			cg, err := codegen.New(nil)
 			require.NoError(t, err, tc.name)
 
@@ -806,7 +807,7 @@ func TestCodeGen(t *testing.T) {
 			err = checker.SemanticPass(mod)
 			require.NoError(t, err, tc.name)
 
-			linter.Lint(mod)
+			linter.Lint(ctx, mod)
 
 			err = checker.Check(mod)
 			require.NoError(t, err, tc.name)
@@ -823,7 +824,7 @@ func TestCodeGen(t *testing.T) {
 				err = checker.SemanticPass(imod)
 				require.NoError(t, err, tc.name)
 
-				linter.Lint(imod)
+				linter.Lint(ctx, imod)
 
 				err = checker.Check(imod)
 				require.NoError(t, err, tc.name)
@@ -839,7 +840,6 @@ func TestCodeGen(t *testing.T) {
 				targets = append(targets, codegen.Target{Name: target})
 			}
 
-			ctx := codegen.WithSessionID(context.Background(), identity.NewID())
 			request, err := cg.Generate(ctx, mod, targets)
 			require.NoError(t, err, tc.name)
 

--- a/hlb.go
+++ b/hlb.go
@@ -42,7 +42,7 @@ func Compile(ctx context.Context, cln *client.Client, targets []codegen.Target, 
 		return nil, err
 	}
 
-	err = linter.Lint(mod, linter.WithRecursive())
+	err = linter.Lint(ctx, mod, linter.WithRecursive())
 	if err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
- Relpaths for imports importing modules from its directory does not properly construct path from hlb process's cwd

## build.hlb
```hlb
import module from "./root/module.hlb"

fs default() {
	module.foo
}
```

## ./root/module.hlb
```hlb
import transient from "./transient.hlb"

export foo
fs foo() {
	transient.bar
}
```

## ./root/transient.hlb
```hlb
export bar

fs bar() {
	image "alpine"
}
```