### PR TITLE
Fix heredoc string interpolation

### DIFF
--- a/parser/cst.go
+++ b/parser/cst.go
@@ -52,7 +52,7 @@ var (
 			{"HeredocEnd", `\b\1\b`, stateful.Pop()},
 			{"Whitespace", `\s+`, nil},
 			{"Interpolated", `\${`, stateful.Push("Interpolated")},
-			{"Text", `[^\s$]+`, nil},
+			{"Text", `\$|[^\s$]+`, nil},
 		},
 		"RawHeredoc": {
 			{"RawHeredocEnd", `\b\1\b`, stateful.Pop()},

--- a/unparse_test.go
+++ b/unparse_test.go
@@ -475,7 +475,8 @@ func TestUnparse(t *testing.T) {
 
 			fs bar() { scratch }
 			`,
-		}, {
+		},
+		{
 			`heredoc`,
 			`
 			string heredocTest() {
@@ -513,6 +514,36 @@ func TestUnparse(t *testing.T) {
 				  is
 				literal
 				EOM
+			}
+			`,
+		},
+		{
+			`string interpolation`,
+			`
+			string default() {
+				"$k"
+			}
+			`,
+			`
+			string default() {
+				"$k"
+			}
+			`,
+		},
+		{
+			`heredoc interpolation`,
+			`
+			fs default() {
+				run <<~repro
+					$k
+				repro
+			}
+			`,
+			`
+			fs default() {
+				run <<~repro
+					$k
+				repro
 			}
 			`,
 		},


### PR DESCRIPTION
Source:
```hlb
fs default() {
	run <<~repro
                $k
        repro
}
```

Before:
```
❯ hlb format foo.hlb
foo.hlb:3:17: no lexer rules in state "Heredoc" matched input text "$k\n        repro..."
exit status 1
```

After:
```sh
❯ hlb format foo.hlb
fs default() {
	run <<~repro
                $k
        repro
}
```