### PR TITLE
Trim space when codegening heredoc folds

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -189,7 +189,7 @@ func (cg *CodeGen) EmitHeredoc(ctx context.Context, scope *parser.Scope, heredoc
 	case "<<-": // dedent
 		return ret.Set(dedent.Dedent(raw))
 	case "<<~": // fold
-		s := bufio.NewScanner(strings.NewReader(raw))
+		s := bufio.NewScanner(strings.NewReader(strings.TrimSpace(raw)))
 		var lines []string
 		for s.Scan() {
 			lines = append(lines, strings.TrimSpace(s.Text()))

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -612,6 +612,21 @@ func TestCodeGen(t *testing.T) {
 			).Root())
 		},
 	}, {
+		"heredoc folding",
+		[]string{"default"},
+		`
+		fs default() {
+			mkfile "foo" 0o644 <<~EOM
+		                Hello world
+		        EOM
+		}
+		`, "",
+		func(ctx context.Context, t *testing.T) solver.Request {
+			return Expect(t, llb.Scratch().File(
+				llb.Mkfile("foo", 0644, []byte("Hello world")),
+			))
+		},
+	}, {
 		"entitlements",
 		[]string{"default"},
 		`


### PR DESCRIPTION
Leading and trailing whitespace is preserved when using `<<~` heredoc folds when it shouldn't. This causes issues when a path is specified as a heredoc and then `os.Stat` fails because there's a trailing space.

Confirmed test fails on master:
```sh
❯ go test -v -run TestCodeGen/heredoc_folding ./codegen
=== RUN   TestCodeGen
=== PAUSE TestCodeGen
=== CONT  TestCodeGen
=== RUN   TestCodeGen/heredoc_folding
--- FAIL: TestCodeGen (0.00s)
    --- FAIL: TestCodeGen/heredoc_folding (0.00s)
        codegen_test.go:866: expected: .
            └── [file]  actions:<input:-1 secondaryInput:-1 mkfile:<path:"/foo" mode:420 data:"Hello world" timestamp:-1 > >
                └── solve options
        codegen_test.go:871: actual: .
            └── [file]  actions:<input:-1 secondaryInput:-1 mkfile:<path:"/foo" mode:420 data:"Hello world " timestamp:-1 > >
                └── solve options
        codegen_test.go:874:
            	Error Trace:	codegen_test.go:874
            	Error:      	Not equal:
            	            	expected: ".\n└── [file]  actions:<input:-1 secondaryInput:-1 mkfile:<path:\"/foo\" mode:420 data:\"Hello world\" timestamp:-1 > > \n    └── solve options\n"
            	            	actual  : ".\n└── [file]  actions:<input:-1 secondaryInput:-1 mkfile:<path:\"/foo\" mode:420 data:\"Hello world \" timestamp:-1 > > \n    └── solve options\n"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,3 +1,3 @@
            	            	 .
            	            	-└── [file]  actions:<input:-1 secondaryInput:-1 mkfile:<path:"/foo" mode:420 data:"Hello world" timestamp:-1 > >
            	            	+└── [file]  actions:<input:-1 secondaryInput:-1 mkfile:<path:"/foo" mode:420 data:"Hello world " timestamp:-1 > >
            	            	     └── solve options
            	Test:       	TestCodeGen/heredoc_folding
            	Messages:   	heredoc folding
FAIL
FAIL	github.com/openllb/hlb/codegen	0.010s
FAIL
```