### PR TITLE
Fix heredoc and blockstmt indentation on unparse

### DIFF
--- a/parser/cst.go
+++ b/parser/cst.go
@@ -327,9 +327,9 @@ func (fl *FieldList) NumFields() int {
 // FieldStmt represents a statement in a list of fields.
 type FieldStmt struct {
 	Mixin
-	Field    *Field        `parser:"( @@ Delimit?"`
-	Newline  *Newline      `parser:"| @@"`
-	Comments *CommentGroup `parser:"| @@ )"`
+	Field   *Field   `parser:"( @@ Delimit?"`
+	Newline *Newline `parser:"| @@"`
+	Comment *Comment `parser:"| @@ )"`
 }
 
 // Field represents a parameter declaration in a signature.

--- a/parser/walk.go
+++ b/parser/walk.go
@@ -97,8 +97,8 @@ func (w *walker) walk(node Node, v Visitor) {
 		switch {
 		case n.Field != nil:
 			w.walk(n.Field, v)
-		case n.Comments != nil:
-			w.walk(n.Comments, v)
+		case n.Comment != nil:
+			w.walk(n.Comment, v)
 		}
 	case *Field:
 		if n.Modifier != nil {

--- a/unparse_test.go
+++ b/unparse_test.go
@@ -518,6 +518,31 @@ func TestUnparse(t *testing.T) {
 			`,
 		},
 		{
+			`nested heredoc`,
+			`
+			string heredoc() {
+				format string {
+						format <<-EOM
+						keep
+						   our
+						 spaces
+						EOM
+				}
+			}
+			`,
+			`
+			string heredoc() {
+				format string {
+					format <<-EOM
+						keep
+						   our
+						 spaces
+					EOM
+				}
+			}
+			`,
+		},
+		{
 			`string interpolation`,
 			`
 			string default() {


### PR DESCRIPTION
Fixes: #195

Now that we have `UnparseOption`, we can do away with the special heredoc marker as well.