### PR TITLE
Add escape fragments to heredocs

### DIFF
--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -627,6 +627,37 @@ func TestCodeGen(t *testing.T) {
 			))
 		},
 	}, {
+		"string escape",
+		[]string{"default"},
+		`
+		fs default() {
+			mkfile "foo" 0o644 "Escape \${PATH} Escape \" Escape \n Escape \\"
+		}
+		`, "",
+		func(ctx context.Context, t *testing.T) solver.Request {
+			return Expect(t, llb.Scratch().File(
+				llb.Mkfile("foo", 0644, []byte("Escape ${PATH} Escape \" Escape \n Escape \\")),
+			))
+		},
+	}, {
+		"heredoc escape",
+		[]string{"default"},
+		`
+		fs default() {
+			mkfile "foo" 0o644 <<~EOM
+				Escape \${PATH}
+				Don't escape \"
+				Don't escape \n
+				Don't escape \\
+		        EOM
+		}
+		`, "",
+		func(ctx context.Context, t *testing.T) solver.Request {
+			return Expect(t, llb.Scratch().File(
+				llb.Mkfile("foo", 0644, []byte(`Escape ${PATH} Don't escape \" Don't escape \n Don't escape \\`)),
+			))
+		},
+	}, {
 		"entitlements",
 		[]string{"default"},
 		`

--- a/langserver/server.go
+++ b/langserver/server.go
@@ -364,7 +364,10 @@ func highlightStringFragment(lines map[int]lsp.SemanticHighlightingTokens, f *pa
 }
 
 func highlightHeredocFragment(lines map[int]lsp.SemanticHighlightingTokens, f *parser.HeredocFragment) {
-	if f.Interpolated != nil {
+	switch {
+	case f.Escaped != nil:
+		highlightNode(lines, f, Comment)
+	case f.Interpolated != nil:
 		highlightExpr(lines, f.Interpolated.Expr)
 	}
 }

--- a/parser/cst.go
+++ b/parser/cst.go
@@ -51,6 +51,7 @@ var (
 		"Heredoc": {
 			{"HeredocEnd", `\b\1\b`, stateful.Pop()},
 			{"Whitespace", `\s+`, nil},
+			{"Escaped", `\\.`, nil},
 			{"Interpolated", `\${`, stateful.Push("Interpolated")},
 			{"Text", `\$|[^\s$]+`, nil},
 		},
@@ -697,6 +698,7 @@ type Heredoc struct {
 type HeredocFragment struct {
 	Mixin
 	Whitespace   *string       `parser:"( @Whitespace"`
+	Escaped      *string       `parser:"| @Escaped"`
 	Interpolated *Interpolated `parser:"| @@"`
 	Text         *string       `parser:"| @(Text | RawText) )"`
 }

--- a/parser/unparse.go
+++ b/parser/unparse.go
@@ -529,6 +529,8 @@ func (hf *HeredocFragment) Unparse(opts ...UnparseOption) string {
 	switch {
 	case hf.Whitespace != nil:
 		return *hf.Whitespace
+	case hf.Escaped != nil:
+		return *hf.Escaped
 	case hf.Interpolated != nil:
 		opts = append(opts, WithNoNewline())
 		return hf.Interpolated.Unparse(opts...)


### PR DESCRIPTION
Allow for escaped fragments within heredocs to keep consistency with string fragments.

Example:
```hlb
fs default() {
	mkfile "foo" 0o644 <<~EOM
		Escape this \${PATH}
        EOM
}
```