### PR TITLE
Allow npm to modify lock but discard the results

### DIFF
--- a/mkdocs.hlb
+++ b/mkdocs.hlb
@@ -1,11 +1,14 @@
 export generatedBuiltin
+
 export generatedMarkdown
+
 export build
+
 export publish
 
-import npm from fs {
-	image "openllb/npm.hlb"
-}
+# import npm from fs {
+# 	image "openllb/npm.hlb"
+# }
 
 import go from fs {
 	image "openllb/go.hlb"
@@ -56,8 +59,8 @@ fs _runHandleBars() {
 				includePatterns "src" "reference"
 			}
 		} "/src" with readonly
-		mount fs { 
-			npm.nodeModules fs {
+		mount fs {
+			nodeModules fs {
 				local "docs/templates" with option {
 					includePatterns "package.json" "package-lock.json"
 				}
@@ -68,20 +71,29 @@ fs _runHandleBars() {
 	}
 }
 
+fs npmInstall(fs src) {
+	image "node:alpine"
+	run "npm install" with option {
+		dir "/src"
+		mount src "/src"
+		mount scratch "/src/node_modules" as nodeModules
+	}
+}
+
 fs _runDocGen() {
 	scratch
 	run "/docgen" "/language/builtin.hlb" "/out/reference.json" with option {
-		mount fs { 
+		mount fs {
 			staticGoBuild "./cmd/docgen" fs {
 				local "." with option {
 					includePatterns "./cmd/docgen" "parser" "builtin/gen" "go.mod" "go.sum"
 				}
 			}
-		 } "/" with readonly
+		} "/" with readonly
 		mount fs {
 			local "language" with option {
-				 includePatterns "builtin.hlb"
-			 }
+				includePatterns "builtin.hlb"
+			}
 		} "language" with readonly
 		mount scratch "/out" as referenceJson
 	}
@@ -90,17 +102,17 @@ fs _runDocGen() {
 fs _runBuiltinGen() {
 	scratch
 	run "/builtingen" "/language/builtin.hlb" "/out/lookup.go" with option {
-		mount fs { 
+		mount fs {
 			staticGoBuild "./cmd/builtingen" fs {
 				local "." with option {
 					includePatterns "./cmd/builtingen" "builtin/gen" "parser" "go.mod" "go.sum"
 				}
 			}
-		 } "/" with readonly
+		} "/" with readonly
 		mount fs {
 			local "language" with option {
-				 includePatterns "builtin.hlb"
-			 }
+				includePatterns "builtin.hlb"
+			}
 		} "language" with readonly
 		mount scratch "/out" as generatedBuiltin
 	}
@@ -132,7 +144,7 @@ fs testSSH() {
 fs sshKeyScan(string host) {
 	mkdir "/root/.ssh" 0o700
 	run string {
-		format "ssh-keyscan %s >> ~/.ssh/known_hosts" host 
+		format "ssh-keyscan %s >> ~/.ssh/known_hosts" host
 	}
 }
 
@@ -147,8 +159,8 @@ fs _fetchGhPagesBranch() {
 				keepGitDir
 			}
 			# we have to recreate the .git/config because the one that 
-			# comes from buildkit has invalid remote.origin.url and
-			# no branch.master properties
+                        # comes from buildkit has invalid remote.origin.url and
+                        # no branch.master properties
 			mkfile ".git/config" 0o644 <<-EOM
 				[core]
 					repositoryformatversion = 0


### PR DESCRIPTION
Npm strikes again.

```
 > /bin/sh -c 'npm install':
#26 1.224 npm notice
#26 1.224 npm noticenpm notice
#26 1.224 npm notice New patch version of npm available! 7.0.3 -> 7.0.5
#26 1.224 npm notice New patch version of npm available! 7.0.3 -> 7.0.5
#26 1.224 npm Changelog: <https://github.com/npm/cli/releases/tag/v7.0.5>
#26 1.224 npm notice Changelog: <https://github.com/npm/cli/releases/tag/v7.0.5>
#26 1.224 npm notice Run `npm install -g npm@7.0.5` to update!
#26 1.224 npm notice notice Run `npm install -g npm@7.0.5` to update!
#26 1.224 npm notice
#26 1.224
#26 1.224 npm ERR! code EROFS
#26 1.224 npm ERR! code EROFS
#26 1.224 npmnpm ERR! syscall open
#26 1.225 npm ERR! path /src/package-lock.json
#26 1.224  ERR! syscall open
#26 1.224 npm ERR! path /src/package-lock.json
#26 1.225 npm ERR! errno -30
#26 1.224 npm ERR! errno -30
#26 1.225 npm ERR! rofs EROFS: read-only file system, open '/src/package-lock.json'
```

Npm `7.0.5` was released 6 hours (as of this PR), and all of the upstream images are only on `7.0.3`.  However, the recommended command runs into the following issue:
```sh
❯ docker run --rm -it --entrypoint npm node:alpine install -g npm@7.0.5
npm notice
npm notice New patch version of npm available! 7.0.3 -> 7.0.5
npm notice Changelog: https://github.com/npm/cli/releases/tag/v7.0.5
npm notice Run npm install -g npm@7.0.5 to update!
npm notice
npm ERR! code EXDEV
npm ERR! syscall rename
npm ERR! path /usr/local/lib/node_modules/npm
npm ERR! dest /usr/local/lib/node_modules/.npm-i9nnxROI
npm ERR! errno -18
npm ERR! EXDEV: cross-device link not permitted, rename '/usr/local/lib/node_modules/npm' -> '/usr/local/lib/node_modules/.npm-i9nnxROI'

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2020-10-24T00_07_53_111Z-debug.log
```

If you then capture the changes to `package-lock.json` locally, the command continues to try to modify the `package-lock.json`, no dice.

If you are thinking, why is `npm install` not respecting the lockfile? Well, turns out they decided to switch out the default behavior some time ago and you're meant to run `npm ci` instead when you actually want it to respect the lockfile.

But you cannot mount a directory at `node_modules` because then you'll run into this:
```sh
#26 0.685  EROFS
#26 0.685 npm ERR! syscall rmdir
#26 0.685 npm ERR! path /src/node_modules/
#26 0.684 npm ERR! errno -30
#26 0.685 npm ERR! errno -30
#26 0.685 npm ERR!npm ERR! rofs EROFS: read-only file system, rmdir '/src/node_modules/'
```

See: https://github.com/npm/cli/issues/564

As of now, they are not fixing it, so lets just resign to `npm install` and discard the `package-lock.json` changes to the oblivion.