### PR TITLE
Fix formatting for multi-line comments

### DIFF
--- a/mkdocs.hlb
+++ b/mkdocs.hlb
@@ -159,8 +159,8 @@ fs _fetchGhPagesBranch() {
 				keepGitDir
 			}
 			# we have to recreate the .git/config because the one that 
-                        # comes from buildkit has invalid remote.origin.url and
-                        # no branch.master properties
+			# comes from buildkit has invalid remote.origin.url and
+			# no branch.master properties
 			mkfile ".git/config" 0o644 <<-EOM
 				[core]
 					repositoryformatversion = 0

--- a/parser/cst.go
+++ b/parser/cst.go
@@ -328,9 +328,9 @@ func (fl *FieldList) NumFields() int {
 // FieldStmt represents a statement in a list of fields.
 type FieldStmt struct {
 	Mixin
-	Field   *Field   `parser:"( @@ Delimit?"`
-	Newline *Newline `parser:"| @@"`
-	Comment *Comment `parser:"| @@ )"`
+	Field    *Field        `parser:"( @@ Delimit?"`
+	Newline  *Newline      `parser:"| @@"`
+	Comments *CommentGroup `parser:"| @@ )"`
 }
 
 // Field represents a parameter declaration in a signature.

--- a/parser/walk.go
+++ b/parser/walk.go
@@ -97,8 +97,8 @@ func (w *walker) walk(node Node, v Visitor) {
 		switch {
 		case n.Field != nil:
 			w.walk(n.Field, v)
-		case n.Comment != nil:
-			w.walk(n.Comment, v)
+		case n.Comments != nil:
+			w.walk(n.Comments, v)
 		}
 	case *Field:
 		if n.Modifier != nil {

--- a/unparse_test.go
+++ b/unparse_test.go
@@ -446,8 +446,8 @@ func TestUnparse(t *testing.T) {
 			fs foo() { # comment
 
 
+				# multi-line
 				# comment
-
 
 				image "alpine" with option { # comment
 					resolve # comment
@@ -464,6 +464,7 @@ func TestUnparse(t *testing.T) {
 			# comment
 			fs foo() { # comment
 
+				# multi-line
 				# comment
 
 				image "alpine" with option { # comment


### PR DESCRIPTION
Previously, a patch changed block formatting from handling newlines to delegating multi-line formatting to the underlying stmt unparsing, since with opts can now be plumbed down via `(parser.Node).Unparse(opts ...parser.UnparseOption)` for metadata like indentation.

However, comment groups didn't appropriately handle tabulation, so this PR fixes that issue and re-introduces comment groups to `FieldStmt`.