### PR TITLE
Cleanup tests and use dedent.Dedent for test cases

### DIFF
--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -66,10 +66,6 @@ type testCase struct {
 	fn        func(ctx context.Context, t *testing.T) solver.Request
 }
 
-func cleanup(value string) string {
-	return dedent.Dedent(value)
-}
-
 func TestCodeGen(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []testCase{{
@@ -846,7 +842,7 @@ func TestCodeGen(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := diagnostic.WithSources(context.Background(), builtin.Sources())
-			mod, err := parser.Parse(ctx, strings.NewReader(cleanup(tc.hlb)))
+			mod, err := parser.Parse(ctx, strings.NewReader(dedent.Dedent(tc.hlb)))
 			require.NoError(t, err, tc.name)
 
 			err = checker.SemanticPass(mod)
@@ -863,7 +859,7 @@ func TestCodeGen(t *testing.T) {
 					t.Fatal(`"other" should be imported by the test module`)
 				}
 
-				imod, err := parser.Parse(ctx, strings.NewReader(cleanup(tc.hlbImport)))
+				imod, err := parser.Parse(ctx, strings.NewReader(dedent.Dedent(tc.hlbImport)))
 				require.NoError(t, err, tc.name)
 
 				err = checker.SemanticPass(imod)

--- a/parser/unparse_test.go
+++ b/parser/unparse_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lithammer/dedent"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,10 +17,7 @@ type testCase struct {
 }
 
 func cleanup(value string) string {
-	result := fmt.Sprintf("%s\n", strings.TrimSpace(value))
-	result = strings.ReplaceAll(result, strings.Repeat("\t", 3), "")
-	result = strings.ReplaceAll(result, "|\n", "| \n")
-	return result
+	return fmt.Sprintf("%s\n", strings.TrimSpace(dedent.Dedent(value)))
 }
 
 func TestUnparse(t *testing.T) {


### PR DESCRIPTION
Fixes indentation in `checker/checker_test.go` and use `dedent.Dedent` instead of the `cleanup` functions.