### PR TITLE
Bump version constant to 0.3

### DIFF
--- a/build.hlb
+++ b/build.hlb
@@ -36,5 +36,5 @@ fs publishDocs() {
 }
 
 fs src() {
-	local "." with includePatterns("**/*.go", "go.mod", "go.sum", ".golangci.yml")
+	local "." with includePatterns("**/*.go", "go.mod", "go.sum", ".golangci.yml", ".git")
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package hlb
 
-var Version = "0.1+unknown"
+var Version = "0.3+unknown"


### PR DESCRIPTION
- Fix the silently broken version subcommand in a previous PR by not including the `.git` directory
- Bump version constant to `0.3`