### PR TITLE
Allow pipelines to run any non-option functions

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -381,7 +381,13 @@ func (c *checker) checkCall(scope *parser.Scope, kset *parser.KindSet, ie *parse
 
 func (c *checker) checkExpr(scope *parser.Scope, kset *parser.KindSet, expr *parser.Expr) error {
 	if kset.Has(parser.Pipeline) {
-		kset = parser.NewKindSet(append(kset.Kinds(), parser.Filesystem)...)
+		kset = parser.NewKindSet(append(
+			kset.Kinds(),
+			parser.String,
+			parser.Int,
+			parser.Bool,
+			parser.Filesystem,
+		)...)
 	}
 	switch {
 	case expr.FuncLit != nil:

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -323,14 +323,14 @@ func TestChecker_Check(t *testing.T) {
 		"basic pipeline support",
 		`
 		pipeline default() {
-			stage pipelineA fs { image "b"; }
+			stage pipelineA image("b")
 			pipelineC
 		}
 		pipeline pipelineA() {
-			stage fs { image "a"; }
+			stage image("a")
 		}
 		pipeline pipelineC() {
-			stage fs { image "c"; }
+			stage localRun("c")
 		}
 		`,
 		nil,

--- a/codegen/value.go
+++ b/codegen/value.go
@@ -118,7 +118,7 @@ func (v *nilValue) Option() (Option, error) {
 }
 
 func (v *nilValue) Request() (solver.Request, error) {
-	return nil, fmt.Errorf("cannot coerce to pipeline")
+	return solver.NilRequest(), nil
 }
 
 func (v *nilValue) Reflect(t reflect.Type) (reflect.Value, error) {


### PR DESCRIPTION
This will allow non-fs functions to be run as a pipeline (e.g. `string localRun` that has side effects).

```
pipeline default() {
    stage localRun("echo msg > foo")
    stage local("foo")
}
```

Another example, where a tarball is made locally before running a build that depends on the tarball made.
```
pipeline default() {
    stage localRun("./make-tarball.sh")
    stage buildDependingOnTarball
}
```