### PR TITLE
Cache image config resolves within a single hlb run

### DIFF
--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -212,6 +212,7 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo
 		targets = append(targets, codegen.Target{Name: target})
 	}
 
+	ctx = codegen.WithImageResolver(ctx, codegen.NewCachedImageResolver(cln))
 	solveReq, err := hlb.Compile(ctx, cln, mod, targets)
 	if err != nil {
 		// Ignore early exits from the debugger.

--- a/codegen/builtin_string.go
+++ b/codegen/builtin_string.go
@@ -137,7 +137,6 @@ func (m Manifest) Call(ctx context.Context, cln *client.Client, ret Register, op
 		resolver = imageutil.NewBufferedImageResolver()
 		matcher  = resolver.MatchDefaultPlatform()
 	)
-
 	var platform *specs.Platform
 	for _, opt := range opts {
 		if p, ok := opt.(*specs.Platform); ok {

--- a/codegen/context.go
+++ b/codegen/context.go
@@ -24,6 +24,7 @@ type (
 	bindingKey        struct{}
 	sessionIDKey      struct{}
 	multiwriterKey    struct{}
+	imageResolverKey  struct{}
 	backtraceKey      struct{}
 )
 
@@ -93,6 +94,15 @@ func WithMultiWriter(ctx context.Context, mw *progress.MultiWriter) context.Cont
 func MultiWriter(ctx context.Context) *progress.MultiWriter {
 	mw, _ := ctx.Value(multiwriterKey{}).(*progress.MultiWriter)
 	return mw
+}
+
+func WithImageResolver(ctx context.Context, resolver llb.ImageMetaResolver) context.Context {
+	return context.WithValue(ctx, imageResolverKey{}, resolver)
+}
+
+func ImageResolver(ctx context.Context) llb.ImageMetaResolver {
+	resolver, _ := ctx.Value(imageResolverKey{}).(llb.ImageMetaResolver)
+	return resolver
 }
 
 type Frame struct {

--- a/codegen/resolver.go
+++ b/codegen/resolver.go
@@ -1,0 +1,77 @@
+package codegen
+
+import (
+	"context"
+	"sync"
+
+	"github.com/docker/buildx/util/progress"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/client/llb"
+	gateway "github.com/moby/buildkit/frontend/gateway/client"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/openllb/hlb/pkg/llbutil"
+	"github.com/openllb/hlb/solver"
+	"golang.org/x/sync/errgroup"
+)
+
+func NewCachedImageResolver(cln *client.Client) llb.ImageMetaResolver {
+	return &cachedImageResolver{
+		cln:   cln,
+		cache: make(map[string]*imageConfig),
+	}
+}
+
+type cachedImageResolver struct {
+	cln   *client.Client
+	cache map[string]*imageConfig
+	mu    sync.RWMutex
+}
+
+type imageConfig struct {
+	dgst   digest.Digest
+	config []byte
+}
+
+func (r *cachedImageResolver) ResolveImageConfig(ctx context.Context, ref string, opt llb.ResolveImageConfigOpt) (dgst digest.Digest, config []byte, err error) {
+	r.mu.RLock()
+	cfg, ok := r.cache[ref]
+	r.mu.RUnlock()
+	if ok {
+		return cfg.dgst, cfg.config, nil
+	}
+
+	s, err := llbutil.NewSession(ctx)
+	if err != nil {
+		return
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		return s.Run(ctx, r.cln.Dialer())
+	})
+
+	g.Go(func() error {
+		var pw progress.Writer
+
+		mw := MultiWriter(ctx)
+		if mw != nil {
+			pw = mw.WithPrefix("", false)
+		}
+
+		return solver.Build(ctx, r.cln, s, pw, func(ctx context.Context, c gateway.Client) (res *gateway.Result, err error) {
+			dgst, config, err = c.ResolveImageConfig(ctx, ref, opt)
+			return gateway.NewResult(), err
+		})
+	})
+
+	err = g.Wait()
+	if err != nil {
+		return
+	}
+
+	r.mu.Lock()
+	r.cache[ref] = &imageConfig{dgst, config}
+	r.mu.Unlock()
+	return
+}


### PR DESCRIPTION
- Previously, we resolve for every `image` call, even if its a duplicate. Since resolve is slow, this may end up being the slowest part of the cached builds.