### PR TITLE
Fix multiple issues with resolving imports

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -53,8 +53,8 @@ func (cg *CodeGen) Generate(ctx context.Context, mod *parser.Module, targets []T
 	var requests []solver.Request
 
 	for i, target := range targets {
-		obj := mod.Scope.Lookup(target.Name)
-		if obj == nil {
+		_, ok := mod.Scope.Objects[target.Name]
+		if !ok {
 			return nil, fmt.Errorf("target %q is not defined in %s", target.Name, mod.Pos.Filename)
 		}
 

--- a/errdefs/errors.go
+++ b/errdefs/errors.go
@@ -2,6 +2,8 @@ package errdefs
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/openllb/hlb/diagnostic"
 	"github.com/openllb/hlb/parser"
@@ -265,4 +267,8 @@ func DefinedMaybeImported(scope *parser.Scope, ie *parser.IdentExpr, decl parser
 		}
 	}
 	return opts
+}
+
+func IsNotExist(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || os.IsNotExist(err) || strings.HasSuffix(err.Error(), "no such file or directory")
 }

--- a/module/resolve.go
+++ b/module/resolve.go
@@ -389,6 +389,7 @@ func resolveGraph(ctx context.Context, info *resolveGraphInfo, res Resolved, mod
 
 	parser.Match(mod, parser.MatchOpts{},
 		func(id *parser.ImportDecl) {
+			res := res
 			g.Go(func() error {
 				var (
 					ctx = codegen.WithProgramCounter(ctx, id.Expr)
@@ -430,7 +431,7 @@ func resolveGraph(ctx context.Context, info *resolveGraphInfo, res Resolved, mod
 
 				rc, err := res.Open(filename)
 				if err != nil {
-					if !os.IsNotExist(err) {
+					if !errdefs.IsNotExist(err) {
 						return err
 					}
 					if id.DeprecatedPath != nil {


### PR DESCRIPTION
- `--target run` says "arguments required" because its trying to execute the
builtin run. we shouldn't allow them to be viable targets
- `no such file or directory` has a race condition where stratum-agent was used
to lookup common.hlb when its supposed to be looking in stratum-hlb-service
- `no such file or directory` doesn't show a good error because buildkit
upstream has a bug, but i have a workaround

Follow up: https://github.com/openllb/hlb/issues/217