### PR TITLE
preserve resolved config when fs used as mount binding

### DIFF
--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -313,6 +313,7 @@ func (r Run) Call(ctx context.Context, cln *client.Client, ret Register, opts Op
 		sessionOpts []llbutil.SessionOption
 		bind        string
 		shlex       = false
+		image       *specs.Image
 	)
 	for _, opt := range opts {
 		switch o := opt.(type) {
@@ -324,6 +325,7 @@ func (r Run) Call(ctx context.Context, cln *client.Client, ret Register, opts Op
 			sessionOpts = append(sessionOpts, o)
 		case *Mount:
 			bind = o.Bind
+			image = o.Image
 		case *Shlex:
 			shlex = true
 		}
@@ -355,6 +357,9 @@ func (r Run) Call(ctx context.Context, cln *client.Client, ret Register, opts Op
 		fs.State = run.GetMount(bind)
 	} else {
 		fs.State = run.Root()
+	}
+	if image != nil {
+		fs.Image = image
 	}
 
 	fs.SolveOpts = append(fs.SolveOpts, solveOpts...)

--- a/codegen/builtin_option.go
+++ b/codegen/builtin_option.go
@@ -682,7 +682,8 @@ func (s Secret) Call(ctx context.Context, cln *client.Client, ret Register, opts
 }
 
 type Mount struct {
-	Bind string
+	Bind  string
+	Image *specs.Image
 }
 
 func (m Mount) Call(ctx context.Context, cln *client.Client, ret Register, opts Option, input Filesystem, mountpoint string) error {
@@ -704,7 +705,7 @@ func (m Mount) Call(ctx context.Context, cln *client.Client, ret Register, opts 
 		if cache != nil {
 			return errdefs.WithBindCacheMount(Binding(ctx).Bind.As, cache)
 		}
-		retOpts = append(retOpts, &Mount{Bind: mountpoint})
+		retOpts = append(retOpts, &Mount{Bind: mountpoint, Image: input.Image})
 	}
 
 	retOpts = append(retOpts, &llbutil.MountRunOption{


### PR DESCRIPTION
Tested with:
```
fs default() {
        mountCore
        dockerLoad "cmdtest:latest"
}

fs core() {
        scratch
        cmd "/this/is/dumb"
}

fs _fromMount() {
        image "busybox"
        run "/bin/true" with option {
                mount core "/mnt" as mountCore
        }
}
```
Desired outcome is the `cmd` from `core` is preserved in the mounted fs