### PR TITLE
module path contains directory

### DIFF
--- a/module/resolve.go
+++ b/module/resolve.go
@@ -124,21 +124,10 @@ type localResolved struct {
 }
 
 func NewLocalResolved(mod *parser.Module) (Resolved, error) {
-	var root string
-
-	// If the module was parsed from stdin, participle will not be able to fill
-	// in the filename the lexemes were parsed from. Then we should use the
-	// working directory as our relative root.
-	if mod.Pos.Filename != "" && mod.Pos.Filename != "/dev/stdin" {
-		root = filepath.Dir(mod.Pos.Filename)
-	} else {
-		var err error
-		root, err = os.Getwd()
-		if err != nil {
-			return nil, err
-		}
+	root, err := os.Getwd()
+	if err != nil {
+		return nil, err
 	}
-
 	return &localResolved{"", root}, nil
 }
 


### PR DESCRIPTION
fixes #223
when we previously used `filepath.Dir(mod.Pos.Filename)` as the root, it would end up prepending the dir name twice.

