### PR TITLE
Underline func lit type for import errors

### DIFF
--- a/errdefs/errors.go
+++ b/errdefs/errors.go
@@ -87,7 +87,7 @@ func WithCallImport(ident parser.Node, decl parser.Node) error {
 func WithImportPathNotExist(err error, expr parser.Node, filename string) error {
 	return expr.WithError(
 		err,
-		expr.Spanf(diagnostic.Primary, "no such file"),
+		expr.Spanf(diagnostic.Primary, "no such file %q", filename),
 	)
 }
 

--- a/module/resolve.go
+++ b/module/resolve.go
@@ -437,6 +437,9 @@ func resolveGraph(ctx context.Context, info *resolveGraphInfo, res Resolved, mod
 					if id.DeprecatedPath != nil {
 						return errdefs.WithImportPathNotExist(err, id.DeprecatedPath, filename)
 					}
+					if id.Expr.FuncLit != nil {
+						return errdefs.WithImportPathNotExist(err, id.Expr.FuncLit.Type, filename)
+					}
 					return errdefs.WithImportPathNotExist(err, id.Expr, filename)
 				}
 				defer rc.Close()


### PR DESCRIPTION
When importing an fs without the file found like so:
```hlb
import nodejs from fs {
	local "./nodejs.hlb"
}
```

This PR fixes the panic:
```sh
[+] Building 0.2s (1/1)                                                                                                                                                                              
 => [import nodejs] local://sha256:<redacted> (nodejs.hlb)                                                                                0.1s
 => => transferring sha256:<redacted>: 32B                                                                                                0.1s
strings: negative Repeat count
goroutine 1 [running]:
runtime/debug.Stack(0xc0006baef8, 0x2173e00, 0x26b0300)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x9d
```

To show this instead:
```hlb
❯ hlb run local.hlb
[+] Building 0.0s (0/1)
error: rpc error: code = Unknown desc = lstat /tmp/buildkit-mount210908402/module.hlb: no such file or directory
local.hlb:1:20:
  │
1 │ import nodejs from fs {
  │                    ^^
  │                    no such file "module.hlb"

aborting due to previous error
```