### PR TITLE
Fix docs quick start compile instructions to match README

### DIFF
--- a/docs/intro/quickstart.md
+++ b/docs/intro/quickstart.md
@@ -6,7 +6,9 @@ If you're on a MacOS or Linux (`linux-amd64`), head on over to [Releases](https:
 
 Otherwise, you can compile HLB yourself using [go](https://golang.org/dl/):
 ```sh
-go get -u github.com/openllb/hlb/cmd/hlb
+git clone https://github.com/openllb/hlb.git
+cd hlb
+go install ./cmd/hlb
 ```
 
 You'll also need to run `buildkitd` somewhere you can connect to. The easiest way if you have [Docker](https://www.docker.com/get-started), is to run a local buildkit container:


### PR DESCRIPTION
Fixes #222 