### PR TITLE
Unparse BuiltinDecl correctly

### DIFF
--- a/checker/builtin.go
+++ b/checker/builtin.go
@@ -24,6 +24,7 @@ func NewBuiltinScope(builtins builtin.BuiltinLookup) *parser.Scope {
 					Ident: fun.Name,
 					Node: &parser.BuiltinDecl{
 						Module:         builtin.Module,
+						Name:           fun.Name.String(),
 						FuncDeclByKind: make(map[parser.Kind]*parser.FuncDecl),
 						CallableByKind: make(map[parser.Kind]parser.Callable),
 					},

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -934,7 +934,7 @@ func TestCodegenError(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := diagnostic.WithSources(context.Background(), builtin.Sources())
-			mod, err := parser.Parse(context.Background(), strings.NewReader(tc.input))
+			mod, err := parser.Parse(ctx, strings.NewReader(tc.input))
 			require.NoError(t, err, "unexpected parse error")
 
 			err = checker.SemanticPass(mod)

--- a/diagnostic/span.go
+++ b/diagnostic/span.go
@@ -95,6 +95,11 @@ func (se *SpanError) Pretty(ctx context.Context, opts ...PrettyOption) string {
 
 		// Sort spans in the same module by line number.
 		spans := spansByFilename[filename]
+
+		if len(spans) == 0 {
+			continue
+		}
+
 		sort.SliceStable(spans, func(i, j int) bool {
 			return spans[i].Start.Line < spans[j].Start.Line
 		})
@@ -112,14 +117,12 @@ func (se *SpanError) Pretty(ctx context.Context, opts ...PrettyOption) string {
 			sections []string
 			prevLn   int
 		)
-		if len(spans) > 0 {
-			// Initialize the previous line number, this will be updated after every
-			// span to determine how the next span render should join with the previous.
-			// (i.e. if there's a gap or there's overlap).
-			prevLn = spans[0].Start.Line - info.NumContext - 1
-			if prevLn < 0 {
-				prevLn = 0
-			}
+		// Initialize the previous line number, this will be updated after every
+		// span to determine how the next span render should join with the previous.
+		// (i.e. if there's a gap or there's overlap).
+		prevLn = spans[0].Start.Line - info.NumContext - 1
+		if prevLn < 0 {
+			prevLn = 0
 		}
 
 		for i, span := range spans {

--- a/parser/cst.go
+++ b/parser/cst.go
@@ -214,6 +214,7 @@ type Export struct {
 // Special type checking rules apply to builtins.
 type BuiltinDecl struct {
 	*Module
+	Name           string
 	FuncDeclByKind map[Kind]*FuncDecl
 	CallableByKind map[Kind]Callable
 }

--- a/parser/unparse.go
+++ b/parser/unparse.go
@@ -34,6 +34,12 @@ func WithNoStmtEnd() UnparseOption {
 	}
 }
 
+func (bd *BuiltinDecl) String() string { return bd.Unparse() }
+
+func (bd *BuiltinDecl) Unparse(opts ...UnparseOption) string {
+	return bd.Name
+}
+
 func (m *Module) String() string { return m.Unparse() }
 
 func (m *Module) Unparse(opts ...UnparseOption) string {


### PR DESCRIPTION
This fixes two problems:

1) `(*SpanError).Pretty` would panic if there were no spans for the
file. This seemed to be an oversight, because the length of `spans` was
checked just below.

2) `Module`'s implementation of `Unparse` was used for `BuiltinDecl`.
This meant that unrecognized builtin errors would end up printing the
whole builtin module instead of just the name of the builtin.