### PR TITLE
Add v1 compatibility container-config

### DIFF
--- a/codegen/builtin_option.go
+++ b/codegen/builtin_option.go
@@ -683,7 +683,7 @@ func (s Secret) Call(ctx context.Context, cln *client.Client, ret Register, opts
 
 type Mount struct {
 	Bind  string
-	Image *specs.Image
+	Image *solver.ImageSpec
 }
 
 func (m Mount) Call(ctx context.Context, cln *client.Client, ret Register, opts Option, input Filesystem, mountpoint string) error {

--- a/codegen/value.go
+++ b/codegen/value.go
@@ -13,7 +13,6 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	digest "github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/openllb/hlb/parser"
 	"github.com/openllb/hlb/pkg/llbutil"
 	"github.com/openllb/hlb/solver"
@@ -138,7 +137,7 @@ func (v *zeroValue) Kind() parser.Kind {
 func (v *zeroValue) Filesystem() (Filesystem, error) {
 	return Filesystem{
 		State: llb.Scratch(),
-		Image: &specs.Image{},
+		Image: &solver.ImageSpec{},
 	}, nil
 }
 
@@ -164,7 +163,7 @@ func (v *zeroValue) Reflect(t reflect.Type) (reflect.Value, error) {
 
 type Filesystem struct {
 	State       llb.State
-	Image       *specs.Image
+	Image       *solver.ImageSpec
 	SolveOpts   []solver.SolveOption
 	SessionOpts []llbutil.SessionOption
 }
@@ -184,7 +183,7 @@ func (v *fsValue) Kind() parser.Kind {
 }
 
 func (v *fsValue) Filesystem() (Filesystem, error) {
-	var image specs.Image
+	var image solver.ImageSpec
 	if v.fs.Image != nil {
 		image = *v.fs.Image
 	}

--- a/solver/solve.go
+++ b/solver/solve.go
@@ -26,8 +26,23 @@ type SolveInfo struct {
 	OutputLocalTarball    bool
 	OutputLocalOCITarball bool
 	Callbacks             []SolveCallback `json:"-"`
-	ImageSpec             *specs.Image
+	ImageSpec             *ImageSpec
 	Entitlements          []entitlements.Entitlement
+}
+
+// ImageSpec is HLB's wrapper for the OCI specs image, allowing for backward
+// compatible features with Docker.
+type ImageSpec struct {
+	specs.Image
+
+	ContainerConfig ContainerConfig `json:"container_config,omitempty"`
+}
+
+// ContainerConfig is the schema1-compatible configuration of the container
+// that is committed into the image.
+type ContainerConfig struct {
+	Cmd    []string          `json:"Cmd"`
+	Labels map[string]string `json:"Labels"`
 }
 
 func WithDownloadDockerTarball(ref string) SolveOption {
@@ -72,9 +87,9 @@ func WithCallback(fn SolveCallback) SolveOption {
 	}
 }
 
-func WithImageSpec(cfg *specs.Image) SolveOption {
+func WithImageSpec(spec *ImageSpec) SolveOption {
 	return func(info *SolveInfo) error {
-		info.ImageSpec = cfg
+		info.ImageSpec = spec
 		return nil
 	}
 }


### PR DESCRIPTION
Some systems depend on the `container_config` from v1 docker manifests (not present in official OCI image specs). Adding a compat layer during `dockerPush` evaluation.

Specifically, it's distributions manifest payload when requesting with `application/vnd.docker.distribution.manifest.v1+json`, activating this code:
https://github.com/distribution/distribution/blob/6affafd1f030087d88f88841bf66a8abe2bf4d24/manifest/schema1/config_builder.go#L183-L190

Modifying last history v1 compatibility with payload from the raw manifest config. This PR allows `container_config` to be plumbed into registry's automatic v1 translation to history with v1 compat.