### PR TITLE
skip fetching rootfs blobs for `manifest`

### DIFF
--- a/pkg/imageutil/buffered_resolver.go
+++ b/pkg/imageutil/buffered_resolver.go
@@ -2,6 +2,7 @@ package imageutil
 
 import (
 	"context"
+	"strings"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
@@ -67,7 +68,15 @@ func (bir *BufferedImageResolver) ResolveImageConfig(ctx context.Context, ref st
 		return desc.Digest, nil, err
 	}
 
+	var ignoreRootfs images.HandlerFunc = func(ctx context.Context, desc specs.Descriptor) ([]specs.Descriptor, error) {
+		if strings.Contains(desc.MediaType, "rootfs") {
+			return nil, images.ErrSkipDesc
+		}
+		return nil, nil
+	}
+
 	handlers := images.Handlers(
+		ignoreRootfs,
 		remotes.FetchHandler(bir, fetcher),
 		images.ChildrenHandler(bir),
 	)


### PR DESCRIPTION
it seems the `manifest` routine was fetching all the image blogs including the data blobs.  This PR filters out any blob with `rootfs` in the type, so it will fetch just the image metadata.  It seems to fix my issue with the function hanging.