### PR TITLE
Show newline symbols in llb.Run custom name

### DIFF
--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -365,7 +365,7 @@ func (r Run) Call(ctx context.Context, cln *client.Client, ret Register, opts Op
 		return err
 	}
 
-	customName := strings.ReplaceAll(shellquote.Join(runArgs...), "\n", "")
+	customName := strings.ReplaceAll(shellquote.Join(runArgs...), "\n", "\\n")
 	runOpts = append(runOpts, llb.Args(runArgs), llb.WithCustomName(customName))
 
 	err = llbutil.ShimReadonlyMountpoints(runOpts)


### PR DESCRIPTION
- Currently newlines from multi-line runs like heredoc are eliminated from the custom name returned back in the progress UI.
- Multi-line progress line items don't render well, but having the literal symbol `\n` looks better and doesn't remove information.