### PR TITLE
Add a createdTime option to dockerPush

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -154,6 +154,9 @@ var (
 		"option::manifest": map[string]parser.Callable{
 			"platform": codegen.Platform{},
 		},
+		"option::dockerPush": map[string]parser.Callable{
+			"createdTime": codegen.CreatedTime{},
+		},
 	}
 )
 

--- a/builtin/lookup.go
+++ b/builtin/lookup.go
@@ -253,6 +253,16 @@ var (
 					},
 				},
 			},
+			"option::dockerPush": LookupByKind{
+				Func: map[string]FuncLookup{
+					"createdTime": FuncLookup{
+						Params: []*parser.Field{
+							parser.NewField(parser.String, "created", false),
+						},
+						Effects: []*parser.Field{},
+					},
+				},
+			},
 			"option::frontend": LookupByKind{
 				Func: map[string]FuncLookup{
 					"input": FuncLookup{
@@ -1147,6 +1157,13 @@ option::copy excludePatterns(variadic string pattern)
 # expanded the same as the docker CLI.
 # @return an option to push the filesystem to a registry.
 fs dockerPush(string ref) binds (string digest)
+
+# Sets the created time of the pushed image.
+#
+# @param created the created time in the RFC3339 format.
+# @return an option to set the created time of the pushed image.
+option::dockerPush createdTime(string created)
+
 
 # Loads the filesystem as a Docker image to the docker client found in your
 # environment.

--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
@@ -594,6 +595,17 @@ func (dp DockerPush) Call(ctx context.Context, cln *client.Client, ret Register,
 	exportFS, err := ret.Filesystem()
 	if err != nil {
 		return err
+	}
+
+	for _, opt := range opts {
+		switch v := opt.(type) {
+		case llb.CreatedTime:
+			t := time.Time(v)
+			exportFS.Image.Created = &t
+			for i := range exportFS.Image.History {
+				exportFS.Image.History[i].Created = &t
+			}
+		}
 	}
 
 	// Maintains compatibility with systems depending on v1 `container_config`

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -857,6 +857,23 @@ func TestCodeGen(t *testing.T) {
 				llb.Dir("/etc"),
 			).Root())
 		},
+	}, {
+		"dockerPush with options",
+		[]string{"default"},
+		`
+		fs default() {
+			scratch
+			run "echo Hello"
+			dockerPush "example/ref" with option {
+				createdTime "2020-04-27T15:04:05Z"
+			}
+		}
+		`, "",
+		func(ctx context.Context, t *testing.T) solver.Request {
+			return Expect(t, llb.Scratch().Run(
+				llb.Shlex("/bin/sh -c 'echo Hello'"),
+			).Root())
+		},
 	}} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -145,8 +145,17 @@
 
 	#!hlb
 	fs default() {
-		dockerPush "ref"
+		dockerPush "ref" with option {
+			createdTime "created"
+		}
 	}
+
+
+#### <span class='hlb-type'>option::dockerPush</span> <span class='hlb-name'>createdTime</span>(<span class='hlb-type'>string</span> <span class='hlb-variable'>created</span>)
+
+!!! info "<span class='hlb-type'>string</span> <span class='hlb-variable'>created</span>"
+	
+
 
 
 

--- a/language/builtin.hlb
+++ b/language/builtin.hlb
@@ -486,6 +486,13 @@ option::copy excludePatterns(variadic string pattern)
 # @return an option to push the filesystem to a registry.
 fs dockerPush(string ref) binds (string digest)
 
+# Sets the created time of the pushed image.
+#
+# @param created the created time in the RFC3339 format.
+# @return an option to set the created time of the pushed image.
+option::dockerPush createdTime(string created)
+
+
 # Loads the filesystem as a Docker image to the docker client found in your
 # environment.
 #


### PR DESCRIPTION
This allows the creation time of a pushed image to be overridden, so the
digest is consistent between runs as long as the layer contents and
other metadata remains the same.