### PR TITLE
Set an empty "created" timestamp when adding a layer, for build reproducibility

### DIFF
--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
@@ -40,10 +41,13 @@ const (
 
 func commitHistory(img *solver.ImageSpec, empty bool, format string, a ...interface{}) {
 	img.History = append(img.History, specs.History{
+		// Set a zero value on Created for more reproducible builds
+		Created:    &time.Time{},
 		CreatedBy:  fmt.Sprintf(format, a...),
 		Comment:    HistoryComment,
 		EmptyLayer: empty,
 	})
+	img.Created = &time.Time{}
 }
 
 type Scratch struct{}


### PR DESCRIPTION
This allows the digest of a pushed build to be consistent between runs
as long as the layer contents and other metadata remains the same.