### PR TITLE
Avoid duplicated log output from parallel solves

### DIFF
--- a/cmd/hlb/command/module.go
+++ b/cmd/hlb/command/module.go
@@ -174,7 +174,7 @@ func Vendor(ctx context.Context, cln *client.Client, info VendorInfo) (err error
 
 	p.Go(func(ctx context.Context) error {
 		defer p.Release()
-		ctx = codegen.WithWriter(ctx, p.Writer())
+		ctx = codegen.WithMultiWriter(ctx, p.MultiWriter())
 		return module.Vendor(ctx, cln, mod, info.Targets, info.Tidy)
 	})
 
@@ -290,7 +290,7 @@ func Tree(ctx context.Context, cln *client.Client, info TreeInfo) (err error) {
 			defer p.Release()
 
 			var err error
-			ctx = codegen.WithWriter(ctx, p.Writer())
+			ctx = codegen.WithMultiWriter(ctx, p.MultiWriter())
 			tree, err = module.NewTree(ctx, cln, mod, info.Long)
 			return err
 		})

--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -142,7 +142,7 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo
 		if err != nil {
 			return err
 		}
-		ctx = codegen.WithWriter(ctx, p.Writer())
+		ctx = codegen.WithMultiWriter(ctx, p.MultiWriter())
 	}
 
 	ctx = diagnostic.WithSources(ctx, builtin.Sources())
@@ -247,7 +247,7 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo
 
 	p.Go(func(ctx context.Context) error {
 		defer p.Release()
-		return solveReq.Solve(ctx, cln, p.Writer())
+		return solveReq.Solve(ctx, cln, p.MultiWriter())
 	})
 
 	return p.Wait()

--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -244,9 +244,9 @@ func (f Frontend) Call(ctx context.Context, cln *client.Client, ret Register, op
 	g.Go(func() error {
 		var pw progress.Writer
 
-		w := Writer(ctx)
-		if w != nil {
-			pw = progress.WithPrefix(w, "", false)
+		mw := MultiWriter(ctx)
+		if mw != nil {
+			pw = mw.WithPrefix("", false)
 		}
 
 		return solver.Build(ctx, cln, s, pw, func(ctx context.Context, c gateway.Client) (res *gateway.Result, err error) {
@@ -630,7 +630,7 @@ func (dp DockerPush) Call(ctx context.Context, cln *client.Client, ret Register,
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		return request.Solve(ctx, cln, Writer(ctx))
+		return request.Solve(ctx, cln, MultiWriter(ctx))
 	})
 
 	if Binding(ctx).Binds() == "digest" {
@@ -690,7 +690,7 @@ func (dl DockerLoad) Call(ctx context.Context, cln *client.Client, ret Register,
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		return request.Solve(ctx, cln, Writer(ctx))
+		return request.Solve(ctx, cln, MultiWriter(ctx))
 	})
 
 	g.Go(func() (err error) {
@@ -726,13 +726,13 @@ func (dl DockerLoad) Call(ctx context.Context, cln *client.Client, ret Register,
 		}
 		defer resp.Body.Close()
 
-		w := Writer(ctx)
-		if w == nil {
+		mw := MultiWriter(ctx)
+		if mw == nil {
 			_, err = io.Copy(ioutil.Discard, resp.Body)
 			return err
 		}
 
-		pw := progress.WithPrefix(w, "", false)
+		pw := mw.WithPrefix("", false)
 		progress.FromReader(pw, fmt.Sprintf("importing %s to docker", ref), resp.Body)
 		return nil
 	})
@@ -776,7 +776,7 @@ func (d Download) Call(ctx context.Context, cln *client.Client, ret Register, op
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		return request.Solve(ctx, cln, Writer(ctx))
+		return request.Solve(ctx, cln, MultiWriter(ctx))
 	})
 
 	fs, err := ret.Filesystem()
@@ -828,7 +828,7 @@ func (dt DownloadTarball) Call(ctx context.Context, cln *client.Client, ret Regi
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		return request.Solve(ctx, cln, Writer(ctx))
+		return request.Solve(ctx, cln, MultiWriter(ctx))
 	})
 
 	fs, err := ret.Filesystem()
@@ -880,7 +880,7 @@ func (dot DownloadOCITarball) Call(ctx context.Context, cln *client.Client, ret 
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		return request.Solve(ctx, cln, Writer(ctx))
+		return request.Solve(ctx, cln, MultiWriter(ctx))
 	})
 
 	fs, err := ret.Filesystem()
@@ -935,7 +935,7 @@ func (dot DownloadDockerTarball) Call(ctx context.Context, cln *client.Client, r
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		return request.Solve(ctx, cln, Writer(ctx))
+		return request.Solve(ctx, cln, MultiWriter(ctx))
 	})
 
 	fs, err := ret.Filesystem()

--- a/codegen/context.go
+++ b/codegen/context.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/docker/buildx/util/progress"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/solver/errdefs"
@@ -23,7 +22,7 @@ type (
 	argKey            struct{ n int }
 	bindingKey        struct{}
 	sessionIDKey      struct{}
-	writerKey         struct{}
+	multiwriterKey    struct{}
 	imageResolverKey  struct{}
 	backtraceKey      struct{}
 )
@@ -87,13 +86,13 @@ func SessionID(ctx context.Context) string {
 	return sessionID
 }
 
-func WithWriter(ctx context.Context, w progress.Writer) context.Context {
-	return context.WithValue(ctx, writerKey{}, w)
+func WithMultiWriter(ctx context.Context, mw *solver.MultiWriter) context.Context {
+	return context.WithValue(ctx, multiwriterKey{}, mw)
 }
 
-func Writer(ctx context.Context) progress.Writer {
-	w, _ := ctx.Value(writerKey{}).(progress.Writer)
-	return w
+func MultiWriter(ctx context.Context) *solver.MultiWriter {
+	mw, _ := ctx.Value(multiwriterKey{}).(*solver.MultiWriter)
+	return mw
 }
 
 func WithImageResolver(ctx context.Context, resolver llb.ImageMetaResolver) context.Context {

--- a/codegen/resolver.go
+++ b/codegen/resolver.go
@@ -54,9 +54,9 @@ func (r *cachedImageResolver) ResolveImageConfig(ctx context.Context, ref string
 	g.Go(func() error {
 		var pw progress.Writer
 
-		w := Writer(ctx)
-		if w != nil {
-			pw = progress.WithPrefix(w, "", false)
+		mw := MultiWriter(ctx)
+		if mw != nil {
+			pw = mw.WithPrefix("", false)
 		}
 
 		return solver.Build(ctx, r.cln, s, pw, func(ctx context.Context, c gateway.Client) (res *gateway.Result, err error) {

--- a/hlb.go
+++ b/hlb.go
@@ -52,7 +52,7 @@ func Compile(ctx context.Context, cln *client.Client, mod *parser.Module, target
 	}
 
 	var opts []codegen.CodeGenOption
-	if codegen.Writer(ctx) == nil {
+	if codegen.MultiWriter(ctx) == nil {
 		r := bufio.NewReader(os.Stdin)
 		opts = append(opts, codegen.WithDebugger(codegen.NewDebugger(cln, os.Stderr, r)))
 	}

--- a/module/resolve.go
+++ b/module/resolve.go
@@ -161,9 +161,9 @@ func (r *remoteResolver) Resolve(ctx context.Context, id *parser.ImportDecl, fs 
 	}
 
 	var pw progress.Writer
-	w := codegen.Writer(ctx)
-	if w != nil {
-		pw = progress.WithPrefix(w, fmt.Sprintf("import %s", id.Name), true)
+	mw := codegen.MultiWriter(ctx)
+	if mw != nil {
+		pw = mw.WithPrefix(fmt.Sprintf("import %s", id.Name), true)
 	}
 
 	// Block constructing remoteResolved until the graph is solved and assigned to

--- a/solver/multiwriter.go
+++ b/solver/multiwriter.go
@@ -1,0 +1,80 @@
+package solver
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/docker/buildx/util/progress"
+	"github.com/moby/buildkit/client"
+	digest "github.com/opencontainers/go-digest"
+)
+
+// MultiWriter is similar to progress.MultiWriter, but deduplicates writes by
+// vertex.
+type MultiWriter struct {
+	w                  progress.Writer
+	allClaimedVertices map[digest.Digest]struct{}
+	claimedVerticesMu  sync.Mutex
+}
+
+func NewMultiWriter(pw progress.Writer) *MultiWriter {
+	if pw == nil {
+		return nil
+	}
+
+	return &MultiWriter{
+		w:                  pw,
+		allClaimedVertices: make(map[digest.Digest]struct{}),
+	}
+}
+
+func (mw *MultiWriter) WithPrefix(pfx string, force bool) progress.Writer {
+	return &prefixed{
+		mw:              mw,
+		pfx:             pfx,
+		force:           force,
+		claimedVertices: make(map[digest.Digest]struct{}),
+	}
+}
+
+type prefixed struct {
+	mw              *MultiWriter
+	pfx             string
+	force           bool
+	claimedVertices map[digest.Digest]struct{}
+}
+
+func (p *prefixed) Write(v *client.SolveStatus) {
+	filtered := &client.SolveStatus{
+		Vertexes: v.Vertexes,
+		Statuses: v.Statuses,
+	}
+
+	p.mw.claimedVerticesMu.Lock()
+	for _, log := range v.Logs {
+		if _, ourVertex := p.claimedVertices[log.Vertex]; ourVertex {
+			filtered.Logs = append(filtered.Logs, log)
+			continue
+		}
+		if _, claimed := p.mw.allClaimedVertices[log.Vertex]; !claimed {
+			p.mw.allClaimedVertices[log.Vertex] = struct{}{}
+			p.claimedVertices[log.Vertex] = struct{}{}
+			filtered.Logs = append(filtered.Logs, log)
+		}
+	}
+	p.mw.claimedVerticesMu.Unlock()
+
+	if p.force {
+		for _, v := range filtered.Vertexes {
+			v.Name = addPrefix(p.pfx, v.Name)
+		}
+	}
+	p.mw.w.Write(filtered)
+}
+
+func addPrefix(pfx, name string) string {
+	if strings.HasPrefix(name, "[") {
+		return "[" + pfx + " " + name[1:]
+	}
+	return "[" + pfx + "] " + name
+}

--- a/solver/request.go
+++ b/solver/request.go
@@ -31,7 +31,7 @@ type Request interface {
 	// Solve sends the request and its children to BuildKit. The request passes
 	// down the progress.Writer for them to spawn their own progress writers
 	// for each independent solve.
-	Solve(ctx context.Context, cln *client.Client, w progress.Writer) error
+	Solve(ctx context.Context, cln *client.Client, mw *MultiWriter) error
 
 	Tree(tree treeprint.Tree) error
 }
@@ -42,7 +42,7 @@ func NilRequest() Request {
 	return &nilRequest{}
 }
 
-func (r *nilRequest) Solve(ctx context.Context, cln *client.Client, w progress.Writer) error {
+func (r *nilRequest) Solve(ctx context.Context, cln *client.Client, mw *MultiWriter) error {
 	return nil
 }
 
@@ -65,10 +65,10 @@ func Single(params *Params) Request {
 	return &singleRequest{params: params}
 }
 
-func (r *singleRequest) Solve(ctx context.Context, cln *client.Client, w progress.Writer) error {
+func (r *singleRequest) Solve(ctx context.Context, cln *client.Client, mw *MultiWriter) error {
 	var pw progress.Writer
-	if w != nil {
-		pw = progress.WithPrefix(w, "", false)
+	if mw != nil {
+		pw = mw.WithPrefix("", false)
 	}
 
 	s, err := llbutil.NewSession(ctx, r.params.SessionOpts...)
@@ -292,12 +292,12 @@ func Parallel(candidates ...Request) Request {
 	return &parallelRequest{reqs: reqs}
 }
 
-func (r *parallelRequest) Solve(ctx context.Context, cln *client.Client, w progress.Writer) error {
+func (r *parallelRequest) Solve(ctx context.Context, cln *client.Client, mw *MultiWriter) error {
 	g, ctx := errgroup.WithContext(ctx)
 	for _, req := range r.reqs {
 		req := req
 		g.Go(func() error {
-			return req.Solve(ctx, cln, w)
+			return req.Solve(ctx, cln, mw)
 		})
 	}
 	return g.Wait()
@@ -338,9 +338,9 @@ func Sequential(candidates ...Request) Request {
 	return &sequentialRequest{reqs: reqs}
 }
 
-func (r *sequentialRequest) Solve(ctx context.Context, cln *client.Client, w progress.Writer) error {
+func (r *sequentialRequest) Solve(ctx context.Context, cln *client.Client, mw *MultiWriter) error {
 	for _, req := range r.reqs {
-		err := req.Solve(ctx, cln, w)
+		err := req.Solve(ctx, cln, mw)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When a parallel solve involves overlapping vertices, HLB may print log
lines multiple times.

This works around the issue by adding our own `MultiWriter` implementation
which keeps track of which `Writer` returned by `WithPrefix` is responsible
for outputting logs for any particular vertex. Writes for the same
vertex will only be allowed through once.

Repro case:

    fs default() {
            output "hi"
            download "."
    }

    fs common(string msg) {
            image "docker-hub.netflix.net/library/busybox"
            run "for i in $(seq 1 10); do echo $i; sleep 1; done" with ignoreCache
            run "echo ${msg} > /output/${msg}" with option {
                    mount scratch "/output" as output
            }
    }