### PR TITLE
Avoid false positive static breakpoint

### DIFF
--- a/codegen/debug.go
+++ b/codegen/debug.go
@@ -409,6 +409,9 @@ func FindStaticBreakpoints(ctx context.Context, mod *parser.Module) []*Breakpoin
 
 	parser.Match(mod, parser.MatchOpts{},
 		func(fun *parser.FuncDecl, call *parser.CallStmt) {
+			if fun.Kind() == "option::run" {
+				return
+			}
 			if !call.Breakpoint(ReturnType(ctx)) {
 				return
 			}


### PR DESCRIPTION
Without this check, `FindStaticBreakpoints` will wrongly see

    option::run breakpointOpt() {
            breakpoint "/overlay-chroot" "/bin/sh"
    }

as a standalone breakpoint