### PR TITLE
Add `Sync` to Progress to synchronize progress while debugging

### DIFF
--- a/cmd/hlb/command/module.go
+++ b/cmd/hlb/command/module.go
@@ -172,13 +172,10 @@ func Vendor(ctx context.Context, cln *client.Client, info VendorInfo) (err error
 		return err
 	}
 
-	p.Go(func(ctx context.Context) error {
-		defer p.Release()
-		ctx = codegen.WithMultiWriter(ctx, p.MultiWriter())
-		return module.Vendor(ctx, cln, mod, info.Targets, info.Tidy)
-	})
-
-	return p.Wait()
+	defer p.Release()
+	defer p.Wait()
+	ctx = codegen.WithMultiWriter(ctx, p.MultiWriter())
+	return module.Vendor(ctx, cln, mod, info.Targets, info.Tidy)
 }
 
 func findVendoredModule(errNotExist error, name string) (io.ReadCloser, error) {
@@ -286,16 +283,11 @@ func Tree(ctx context.Context, cln *client.Client, info TreeInfo) (err error) {
 			return err
 		}
 
-		p.Go(func(ctx context.Context) error {
-			defer p.Release()
+		defer p.Release()
+		defer p.Wait()
 
-			var err error
-			ctx = codegen.WithMultiWriter(ctx, p.MultiWriter())
-			tree, err = module.NewTree(ctx, cln, mod, info.Long)
-			return err
-		})
-
-		err = p.Wait()
+		ctx := codegen.WithMultiWriter(ctx, p.MultiWriter())
+		tree, err = module.NewTree(ctx, cln, mod, info.Long)
 		if err != nil {
 			return err
 		}

--- a/codegen/context.go
+++ b/codegen/context.go
@@ -25,6 +25,7 @@ type (
 	multiwriterKey    struct{}
 	imageResolverKey  struct{}
 	backtraceKey      struct{}
+	progressKey       struct{}
 )
 
 func WithProgramCounter(ctx context.Context, node parser.Node) context.Context {
@@ -93,6 +94,15 @@ func WithMultiWriter(ctx context.Context, mw *solver.MultiWriter) context.Contex
 func MultiWriter(ctx context.Context) *solver.MultiWriter {
 	mw, _ := ctx.Value(multiwriterKey{}).(*solver.MultiWriter)
 	return mw
+}
+
+func WithProgress(ctx context.Context, p solver.Progress) context.Context {
+	return context.WithValue(ctx, progressKey{}, p)
+}
+
+func Progress(ctx context.Context) solver.Progress {
+	p, _ := ctx.Value(progressKey{}).(solver.Progress)
+	return p
 }
 
 func WithImageResolver(ctx context.Context, resolver llb.ImageMetaResolver) context.Context {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/alecthomas/participle v1.0.0-alpha2
+	github.com/containerd/console v1.0.2
 	github.com/containerd/containerd v1.5.2
 	github.com/creachadair/jrpc2 v0.8.1
 	github.com/docker/buildx v0.5.1


### PR DESCRIPTION
This will now show the "plain" progress while debugging.  The goal is to ensure all progress output is flushed at various points, this is essential while in the debugger especially before we exec into a container.   There is no way to sync the progress writers we use upstream, but we can wait for completion, so this PR creates a `Sync` func in our progress writer which basically shuts down the current progress writer and waits for completion, then recreates the progress writer so that we can continue to collect progress later.