### PR TITLE
fix missing progress wait on exit from debugger

### DIFF
--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -210,9 +210,10 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo
 	solveReq, err := hlb.Compile(ctx, cln, mod, targets, opts...)
 	if err != nil {
 		p.Release()
+		perr := p.Wait()
 		// Ignore early exits from the debugger.
 		if err == codegen.ErrDebugExit {
-			return nil
+			return perr
 		}
 		return err
 	}


### PR DESCRIPTION
found this with goleak testing