### PR TITLE
Update github.com/creachadair/jrpc2 to v0.19.0.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/participle v1.0.0-alpha2
 	github.com/containerd/console v1.0.2
 	github.com/containerd/containerd v1.5.2
-	github.com/creachadair/jrpc2 v0.8.1
+	github.com/creachadair/jrpc2 v0.19.0
 	github.com/docker/buildx v0.5.1
 	github.com/docker/cli v20.10.7+incompatible
 	github.com/docker/distribution v2.7.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,5 @@
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 bazil.org/fuse v0.0.0-20180421153158-65cc252bf669/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
-bitbucket.org/creachadair/shell v0.0.6/go.mod h1:8Qqi/cYk7vPnsOePHroKXDJYmb5x7ENhtiFtfZq8K+M=
-bitbucket.org/creachadair/stringset v0.0.8 h1:gQqe4vs8XWgMyijfyKE6K8o4TcyGGrRXe0JvHgx5H+M=
-bitbucket.org/creachadair/stringset v0.0.8/go.mod h1:AgthVMyMxC/6FK1KBJ2ALdqkZObGN8hOetgpwXyMn34=
 cloud.google.com/go v0.25.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.31.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -364,9 +361,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/creachadair/jrpc2 v0.8.1 h1:YX27WgtXa9v7g0kn3oYe7gmxt7e5M3miVgEgTXoTqcY=
-github.com/creachadair/jrpc2 v0.8.1/go.mod h1:yMFI6NwXGITWoWDEEdmZESIHp13SAuSkGCTBz9bSGBg=
-github.com/creachadair/staticfile v0.1.2/go.mod h1:a3qySzCIXEprDGxk6tSxSI+dBBdLzqeBOMhZ+o2d3pM=
+github.com/creachadair/jrpc2 v0.19.0 h1:Z+4Q/lmuzqD/NWqOcNqEXEApWy5TApeRRiPDtSWm0g4=
+github.com/creachadair/jrpc2 v0.19.0/go.mod h1:gaeysmTjY/kHSaCEjxF1pHXl8bc0X5otQPnQiA6r9Xk=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=

--- a/langserver/server.go
+++ b/langserver/server.go
@@ -173,7 +173,7 @@ func (ls *LangServer) publishSemanticHighlighting(ctx context.Context, td TextDo
 		})
 	}
 
-	return ls.server.Push(ctx, "textDocument/semanticHighlighting", params)
+	return ls.server.Notify(ctx, "textDocument/semanticHighlighting", params)
 }
 
 func highlightModule(lines map[int]lsp.SemanticHighlightingTokens, mod *parser.Module) {


### PR DESCRIPTION
In preparation for committing to a stable v1 release for jrpc2 package, I have
made a number of updates to the library to simplify the API a bit. These
changes are discussed in creachadair/jrpc2#46 if you would like to offer input.

This commit updates the package version used here to the latest tag as of this
writing, v0.19.0, and updates the existing use to match the changes. These
changes should not produce any functional differences.