### PR TITLE
add option::image platform to specify desired platform

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -63,7 +63,8 @@ var (
 			"parallel": codegen.Stage{},
 		},
 		"option::image": {
-			"resolve": codegen.Resolve{},
+			"resolve":  codegen.Resolve{},
+			"platform": codegen.Platform{},
 		},
 		"option::http": {
 			"checksum": codegen.Checksum{},

--- a/builtin/lookup.go
+++ b/builtin/lookup.go
@@ -313,6 +313,13 @@ var (
 						Params:  []*parser.Field{},
 						Effects: []*parser.Field{},
 					},
+					"platform": {
+						Params: []*parser.Field{
+							parser.NewField(parser.String, "os", false),
+							parser.NewField(parser.String, "arch", false),
+						},
+						Effects: []*parser.Field{},
+					},
 				},
 			},
 			"option::local": {
@@ -689,6 +696,11 @@ fs image(string ref)
 #
 # @return an option to resolve the image&#39;s OCI image config.
 option::image resolve()
+
+# Specifies the desired platform for a multi-platform docker image.
+#
+# @return an option to specify the platform for an OCI image config.
+option::image platform(string os, string arch)
 
 # A filesystem with a file retrieved from a HTTP URL.
 #

--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -60,10 +60,16 @@ type Image struct{}
 
 func (i Image) Call(ctx context.Context, cln *client.Client, ret Register, opts Option, ref string) error {
 	var imageOpts []llb.ImageOption
+	platform := DefaultPlatform(ctx)
+	resolveOpt := llb.ResolveImageConfigOpt{
+		Platform: &platform,
+	}
 	for _, opt := range opts {
 		switch o := opt.(type) {
 		case llb.ImageOption:
 			imageOpts = append(imageOpts, o)
+		case *specs.Platform:
+			resolveOpt.Platform = o
 		}
 	}
 	for _, opt := range SourceMap(ctx) {
@@ -83,7 +89,7 @@ func (i Image) Call(ctx context.Context, cln *client.Client, ret Register, opts 
 	)
 
 	if resolver != nil {
-		_, config, err := resolver.ResolveImageConfig(ctx, ref, llb.ResolveImageConfigOpt{})
+		_, config, err := resolver.ResolveImageConfig(ctx, ref, resolveOpt)
 		if err != nil {
 			return err
 		}

--- a/codegen/builtin_option.go
+++ b/codegen/builtin_option.go
@@ -121,7 +121,7 @@ func (fi FrontendInput) Call(ctx context.Context, cln *client.Client, ret Regist
 		return err
 	}
 
-	def, err := input.State.Marshal(ctx, llb.LinuxAmd64)
+	def, err := input.State.Marshal(ctx, llb.Platform(DefaultPlatform(ctx)))
 	if err != nil {
 		return err
 	}

--- a/codegen/context.go
+++ b/codegen/context.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/solver/pb"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/openllb/hlb/diagnostic"
 	"github.com/openllb/hlb/parser"
 	"github.com/openllb/hlb/pkg/llbutil"
@@ -26,6 +27,7 @@ type (
 	imageResolverKey  struct{}
 	backtraceKey      struct{}
 	progressKey       struct{}
+	platformKey       struct{}
 )
 
 func WithProgramCounter(ctx context.Context, node parser.Node) context.Context {
@@ -175,4 +177,16 @@ func SourceMap(ctx context.Context) (opts []llb.ConstraintsOpt) {
 	}
 
 	return
+}
+
+func WithDefaultPlatform(ctx context.Context, platform specs.Platform) context.Context {
+	return context.WithValue(ctx, platformKey{}, platform)
+}
+
+func DefaultPlatform(ctx context.Context) specs.Platform {
+	platform, ok := ctx.Value(platformKey{}).(specs.Platform)
+	if !ok {
+		return specs.Platform{OS: "linux", Architecture: "amd64"}
+	}
+	return platform
 }

--- a/codegen/debug.go
+++ b/codegen/debug.go
@@ -451,7 +451,7 @@ func AtBreakpoint(node parser.Node, fun *parser.FuncDecl, breakpoints []*Breakpo
 }
 
 func printGraph(ctx context.Context, st llb.State, sh string) error {
-	def, err := st.Marshal(ctx, llb.LinuxAmd64)
+	def, err := st.Marshal(ctx, llb.Platform(DefaultPlatform(ctx)))
 	if err != nil {
 		return err
 	}
@@ -680,7 +680,7 @@ func ExecWithFS(ctx context.Context, cln *client.Client, fs Filesystem, r io.Rea
 
 				if gatewayMount.MountType == pb.MountType_BIND {
 					var def *llb.Definition
-					def, err = mount.Source.Marshal(ctx, llb.LinuxAmd64)
+					def, err = mount.Source.Marshal(ctx, llb.Platform(DefaultPlatform(ctx)))
 					if err != nil {
 						return
 					}

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -373,9 +373,19 @@
 	#!hlb
 	fs default() {
 		image "ref" with option {
+			platform "os" "arch"
 			resolve
 		}
 	}
+
+
+#### <span class='hlb-type'>option::image</span> <span class='hlb-name'>platform</span>(<span class='hlb-type'>string</span> <span class='hlb-variable'>os</span>, <span class='hlb-type'>string</span> <span class='hlb-variable'>arch</span>)
+
+!!! info "<span class='hlb-type'>string</span> <span class='hlb-variable'>os</span>"
+	
+!!! info "<span class='hlb-type'>string</span> <span class='hlb-variable'>arch</span>"
+	
+
 
 
 #### <span class='hlb-type'>option::image</span> <span class='hlb-name'>resolve</span>()

--- a/language/builtin.hlb
+++ b/language/builtin.hlb
@@ -16,6 +16,11 @@ fs image(string ref)
 # @return an option to resolve the image's OCI image config.
 option::image resolve()
 
+# Specifies the desired platform for a multi-platform docker image.
+#
+# @return an option to specify the platform for an OCI image config.
+option::image platform(string os, string arch)
+
 # A filesystem with a file retrieved from a HTTP URL.
 #
 # @param url a fully-qualified URL to send a HTTP GET request.

--- a/module/resolve.go
+++ b/module/resolve.go
@@ -155,7 +155,7 @@ func (r *remoteResolver) Resolve(ctx context.Context, id *parser.ImportDecl, fs 
 		return nil, err
 	}
 
-	def, err := fs.State.Marshal(ctx, llb.LinuxAmd64)
+	def, err := fs.State.Marshal(ctx, llb.Platform(codegen.DefaultPlatform(ctx)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Also adds a --platform option to `hlb run` to alter the default (linux/amd64) platform for images.