### PR TITLE
capture platform for fs's so we can ensure correct execution context

### DIFF
--- a/codegen/builtin_option.go
+++ b/codegen/builtin_option.go
@@ -121,7 +121,7 @@ func (fi FrontendInput) Call(ctx context.Context, cln *client.Client, ret Regist
 		return err
 	}
 
-	def, err := input.State.Marshal(ctx, llb.Platform(DefaultPlatform(ctx)))
+	def, err := input.State.Marshal(ctx, llb.Platform(input.Platform))
 	if err != nil {
 		return err
 	}

--- a/codegen/context.go
+++ b/codegen/context.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"context"
 	"path/filepath"
+	"runtime"
 
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
@@ -186,7 +187,7 @@ func WithDefaultPlatform(ctx context.Context, platform specs.Platform) context.C
 func DefaultPlatform(ctx context.Context) specs.Platform {
 	platform, ok := ctx.Value(platformKey{}).(specs.Platform)
 	if !ok {
-		return specs.Platform{OS: "linux", Architecture: "amd64"}
+		return specs.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
 	}
 	return platform
 }

--- a/codegen/debug.go
+++ b/codegen/debug.go
@@ -18,6 +18,7 @@ import (
 	solvererrdefs "github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/solver/pb"
 	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/openllb/hlb/diagnostic"
 	"github.com/openllb/hlb/errdefs"
 	"github.com/openllb/hlb/parser"
@@ -219,7 +220,7 @@ func NewDebugger(c *client.Client, w io.Writer, inputSteerer *InputSteerer, prom
 						sh = args[1]
 					}
 
-					err = printGraph(ctx, fs.State, sh)
+					err = printGraph(ctx, fs.State, fs.Platform, sh)
 					if err != nil {
 						fmt.Fprintln(w, "err:", err)
 					}
@@ -450,8 +451,8 @@ func AtBreakpoint(node parser.Node, fun *parser.FuncDecl, breakpoints []*Breakpo
 	return false
 }
 
-func printGraph(ctx context.Context, st llb.State, sh string) error {
-	def, err := st.Marshal(ctx, llb.Platform(DefaultPlatform(ctx)))
+func printGraph(ctx context.Context, st llb.State, p specs.Platform, sh string) error {
+	def, err := st.Marshal(ctx, llb.Platform(p))
 	if err != nil {
 		return err
 	}
@@ -680,7 +681,7 @@ func ExecWithFS(ctx context.Context, cln *client.Client, fs Filesystem, r io.Rea
 
 				if gatewayMount.MountType == pb.MountType_BIND {
 					var def *llb.Definition
-					def, err = mount.Source.Marshal(ctx, llb.Platform(DefaultPlatform(ctx)))
+					def, err = mount.Source.Marshal(ctx, llb.Platform(fs.Platform))
 					if err != nil {
 						return
 					}

--- a/codegen/value.go
+++ b/codegen/value.go
@@ -168,6 +168,7 @@ type Filesystem struct {
 	Image       *solver.ImageSpec
 	SolveOpts   []solver.SolveOption
 	SessionOpts []llbutil.SessionOption
+	Platform    specs.Platform
 }
 
 func (fs Filesystem) Digest(ctx context.Context) (digest.Digest, error) {
@@ -195,6 +196,7 @@ func (v *fsValue) Filesystem() (Filesystem, error) {
 		Image:       &image,
 		SolveOpts:   make([]solver.SolveOption, len(v.fs.SolveOpts)),
 		SessionOpts: make([]llbutil.SessionOption, len(v.fs.SessionOpts)),
+		Platform:    v.fs.Platform,
 	}
 	copy(fs.SolveOpts, v.fs.SolveOpts)
 	copy(fs.SessionOpts, v.fs.SessionOpts)
@@ -202,14 +204,7 @@ func (v *fsValue) Filesystem() (Filesystem, error) {
 }
 
 func (v *fsValue) Request() (solver.Request, error) {
-	// TODO this should probably derive from DefaultPlatform(ctx) but we
-	// dont have ctx in scope here. Not sure of the implications of adding
-	// ctx to the API yet.
-	p := llb.LinuxAmd64
-	if v.fs.Image != nil && v.fs.Image.OS != "" && v.fs.Image.Architecture != "" {
-		p = llb.Platform(specs.Platform{OS: v.fs.Image.OS, Architecture: v.fs.Image.Architecture})
-	}
-	def, err := v.fs.State.Marshal(context.Background(), p)
+	def, err := v.fs.State.Marshal(context.Background(), llb.Platform(v.fs.Platform))
 	if err != nil {
 		return nil, err
 	}

--- a/module/resolve.go
+++ b/module/resolve.go
@@ -155,7 +155,7 @@ func (r *remoteResolver) Resolve(ctx context.Context, id *parser.ImportDecl, fs 
 		return nil, err
 	}
 
-	def, err := fs.State.Marshal(ctx, llb.Platform(codegen.DefaultPlatform(ctx)))
+	def, err := fs.State.Marshal(ctx, llb.Platform(fs.Platform))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes the platform that is auto-magically swapping to the "default platform" when capturing fs's from mounts.   We now preserve the requested platform from the image and plumb it through were necessary.

Also `--debug` will now have the correct platform from the fs's image.