### PR TITLE
fix zero-value fs platform

### DIFF
--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -258,7 +258,7 @@ func (f Frontend) Call(ctx context.Context, cln *client.Client, ret Register, op
 		return s.Run(ctx, cln.Dialer())
 	})
 
-	fs, err := ZeroValue().Filesystem()
+	fs, err := ZeroValue(ctx).Filesystem()
 	if err != nil {
 		return err
 	}
@@ -662,7 +662,7 @@ func (dp DockerPush) Call(ctx context.Context, cln *client.Client, ret Register,
 		}
 	}
 
-	v, err := NewValue(exportFS)
+	v, err := NewValue(ctx, exportFS)
 	if err != nil {
 		return err
 	}
@@ -728,7 +728,7 @@ func (dl DockerLoad) Call(ctx context.Context, cln *client.Client, ret Register,
 	r, w := io.Pipe()
 	exportFS.SessionOpts = append(exportFS.SessionOpts, llbutil.WithSyncTarget(llbutil.OutputFromWriter(w)))
 
-	v, err := NewValue(exportFS)
+	v, err := NewValue(ctx, exportFS)
 	if err != nil {
 		return err
 	}
@@ -821,7 +821,7 @@ func (d Download) Call(ctx context.Context, cln *client.Client, ret Register, op
 
 	exportFS.SessionOpts = append(exportFS.SessionOpts, llbutil.WithSyncTargetDir(localPath))
 
-	v, err := NewValue(exportFS)
+	v, err := NewValue(ctx, exportFS)
 	if err != nil {
 		return err
 	}
@@ -880,7 +880,7 @@ func (dt DownloadTarball) Call(ctx context.Context, cln *client.Client, ret Regi
 
 	exportFS.SessionOpts = append(exportFS.SessionOpts, llbutil.WithSyncTarget(llbutil.OutputFromWriter(f)))
 
-	v, err := NewValue(exportFS)
+	v, err := NewValue(ctx, exportFS)
 	if err != nil {
 		return err
 	}
@@ -939,7 +939,7 @@ func (dot DownloadOCITarball) Call(ctx context.Context, cln *client.Client, ret 
 
 	exportFS.SessionOpts = append(exportFS.SessionOpts, llbutil.WithSyncTarget(llbutil.OutputFromWriter(f)))
 
-	v, err := NewValue(exportFS)
+	v, err := NewValue(ctx, exportFS)
 	if err != nil {
 		return err
 	}
@@ -1001,7 +1001,7 @@ func (dot DownloadDockerTarball) Call(ctx context.Context, cln *client.Client, r
 
 	exportFS.SessionOpts = append(exportFS.SessionOpts, llbutil.WithSyncTarget(llbutil.OutputFromWriter(f)))
 
-	v, err := NewValue(exportFS)
+	v, err := NewValue(ctx, exportFS)
 	if err != nil {
 		return err
 	}

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -78,7 +78,7 @@ func (cg *CodeGen) Generate(ctx context.Context, mod *parser.Module, targets []T
 		ie.Pos.Line = i
 
 		// Every target has a return register.
-		ret := NewRegister()
+		ret := NewRegister(ctx)
 		err = cg.EmitIdentExpr(ctx, mod.Scope, ie, ie.Ident, nil, nil, nil, ret)
 		if err != nil {
 			return nil, err
@@ -151,7 +151,7 @@ func (cg *CodeGen) EmitStringLit(ctx context.Context, scope *parser.Scope, str *
 				pieces = append(pieces, string(value))
 			}
 		case f.Interpolated != nil:
-			exprRet := NewRegister()
+			exprRet := NewRegister(ctx)
 			err := cg.EmitExpr(ctx, scope, f.Interpolated.Expr, nil, nil, nil, exprRet)
 			if err != nil {
 				return err
@@ -184,7 +184,7 @@ func (cg *CodeGen) EmitHeredoc(ctx context.Context, scope *parser.Scope, heredoc
 				pieces = append(pieces, escaped)
 			}
 		case f.Interpolated != nil:
-			exprRet := NewRegister()
+			exprRet := NewRegister(ctx)
 			err := cg.EmitExpr(ctx, scope, f.Interpolated.Expr, nil, nil, nil, exprRet)
 			if err != nil {
 				return err
@@ -284,7 +284,7 @@ func (cg *CodeGen) EmitIdentExpr(ctx context.Context, scope *parser.Scope, ie *p
 		}
 		return cg.EmitIdentExpr(ctx, importScope, ie, ie.Reference.Ident, args, opts, nil, ret)
 	case *parser.Field:
-		val, err := NewValue(obj.Data)
+		val, err := NewValue(ctx, obj.Data)
 		if err != nil {
 			return err
 		}
@@ -503,7 +503,7 @@ func (cg *CodeGen) Evaluate(ctx context.Context, scope *parser.Scope, hint parse
 		ctx = WithReturnType(ctx, hint)
 
 		// Evaluated expressions write to a new return register.
-		ret := NewRegister()
+		ret := NewRegister(ctx)
 
 		err = cg.EmitExpr(ctx, scope, expr, nil, nil, b, ret)
 		if err != nil {

--- a/langserver/server.go
+++ b/langserver/server.go
@@ -539,7 +539,7 @@ func (ls *LangServer) textDocumentDefinitionHandler(ctx context.Context, params 
 				return
 			}
 
-			ret := codegen.NewRegister()
+			ret := codegen.NewRegister(ctx)
 			err = cg.EmitExpr(ctx, block.Scope, id.Expr, nil, nil, nil, ret)
 			if err != nil {
 				log.Printf("failed to generate import: %s", err)

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -84,7 +84,7 @@ func (l *Linter) LintRecursive(ctx context.Context, mod *parser.Module, expr *pa
 		return
 	}
 
-	ret := codegen.NewRegister()
+	ret := codegen.NewRegister(ctx)
 	err = cg.EmitExpr(ctx, mod.Scope, expr, nil, nil, nil, ret)
 	if err != nil {
 		return

--- a/module/resolve.go
+++ b/module/resolve.go
@@ -382,7 +382,7 @@ func resolveGraph(ctx context.Context, info *resolveGraphInfo, res Resolved, mod
 			g.Go(func() error {
 				var (
 					ctx = codegen.WithProgramCounter(ctx, id.Expr)
-					ret = codegen.NewRegister()
+					ret = codegen.NewRegister(ctx)
 				)
 				err := cg.EmitExpr(ctx, mod.Scope, id.Expr, nil, nil, nil, ret)
 				if err != nil {


### PR DESCRIPTION
As per usual, I was wrong: https://github.com/openllb/hlb/pull/275#discussion_r764482749

The empty Platform for the `zeroValue`  Filesystem is  used when we are operating directly on scratch, something like this:
```
fs default() {
	copy build "/output" "."
        # ^^^^ we are solving this with the platform from the `zeroValue` which now fails
	download "."
}

fs build() {
	image "alpine"
	mkdir "/output" 0o755
	run "touch /output/i-was-here"
}
```

We need to default the `zeroValue` platform to a valid value, otherwise we will get a `no match for platform in manifest: not found` error.