### PR TITLE
Refactor usage of llb.Local name and key hint

### DIFF
--- a/pkg/llbutil/id.go
+++ b/pkg/llbutil/id.go
@@ -14,13 +14,13 @@ import (
 // LocalID returns a consistent hash for this local (path + options) so that
 // the same content doesn't get transported multiple times when referenced
 // repeatedly.
-func LocalID(ctx context.Context, cwd, path string, opts ...llb.LocalOption) (string, error) {
-	uniqID, err := LocalUniqueID(cwd)
+func LocalID(ctx context.Context, absPath string, opts ...llb.LocalOption) (string, error) {
+	uniqID, err := LocalUniqueID(absPath)
 	if err != nil {
 		return "", err
 	}
 	opts = append(opts, llb.LocalUniqueID(uniqID))
-	st := llb.Local(path, opts...)
+	st := llb.Local("", opts...)
 
 	def, err := st.Marshal(ctx)
 	if err != nil {

--- a/pkg/llbutil/session.go
+++ b/pkg/llbutil/session.go
@@ -110,6 +110,17 @@ func NewSession(ctx context.Context, opts ...SessionOption) (*session.Session, e
 		attachables = append(attachables, secretsprovider.NewSecretProvider(fileStore))
 	}
 
+	// SharedKey is empty because we already use `llb.SharedKeyHint` for locals.
+	//
+	// Currently, the only use of SharedKey is in the calculation of the cache key
+	// for local immutable ref in BuildKit. There isn't any functional difference
+	// between `llb.SharedKeyHint` and a session's shared key atm. If anything
+	// needs to start leveraging the session's shared key in the future, we
+	// should probably use the codegen.Session(ctx) session id.
+	//
+	// For now, locals also have `llb.LocalUniqueID` that introduces a random
+	// unique ID if a session isn't provided, so regardless of session shared key
+	// being provided or not, we still need to use `llb.SharedKeyHint`.
 	s, err := session.NewSession(ctx, "hlb", "")
 	if err != nil {
 		return s, err

--- a/solver/request.go
+++ b/solver/request.go
@@ -11,11 +11,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const (
-	// LocalPathDescriptionKey is the key name in the metadata description map for the input path to a local fs.
-	LocalPathDescriptionKey = "hlb.local.path"
-)
-
 // Request is a node in the solve request tree produced by the compiler. The
 // solve request tree has peer nodes that should be executed in parallel, and
 // next nodes that should be executed sequentially. These can be intermingled


### PR DESCRIPTION
- Removes `solver.LocalPathDescriptionKey`, it was used only to see what local's digest actually pointed to in the solver tree. Since the path is now part of the local name, this isn't necessary anymore. (https://github.com/openllb/hlb/pull/97#issuecomment-614268142)
- Use `localPath` as name for `llb.Local`, but under the hood use abs path for sync dir
- Use our deterministic ID in `llb.SharedKeyHint` instead, not visible to end user but gives us the same benefits
- Include filename in `localPath` when specifying a file directory with `local "filename"`. Doesn't have any functional difference but makes the output better

Before
```
~/tmp
❯ cat foo.hlb
fs default() {
	local "foo.hlb"
}

~/tmp
❯ hlb run foo.hlb
[+] Building 0.0s (1/1) FINISHED
 => local://sha256:408dc57624f1359d2eaa3b6ef97dcff3b16d16125db02684613a33a8aec2bec0 (foo.hlb)
 => => transferring sha256:408dc57624f1359d2eaa3b6ef97dcff3b16d16125db02684613a33a8aec2bec0: 28B
```

After
```
~/tmp
❯ cat foo.hlb
fs default() {
	local "foo.hlb"
}

~/tmp
❯ hlb run foo.hlb
[+] Building 0.0s (1/1) FINISHED
 => local://foo.hlb (foo.hlb)
 => => transferring foo.hlb: 28B
```