### PR TITLE
Refactor import modules into codegen using lazy async

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -2,11 +2,8 @@ package builtin
 
 import (
 	"context"
-	"fmt"
-	"reflect"
 	"strings"
 
-	"github.com/openllb/hlb/codegen"
 	"github.com/openllb/hlb/diagnostic"
 	"github.com/openllb/hlb/parser"
 	"github.com/openllb/hlb/pkg/filebuffer"
@@ -17,149 +14,6 @@ var (
 	Module *parser.Module
 
 	FileBuffer *filebuffer.FileBuffer
-
-	Callables = map[parser.Kind]map[string]parser.Callable{
-		parser.Filesystem: {
-			"scratch":               codegen.Scratch{},
-			"image":                 codegen.Image{},
-			"http":                  codegen.HTTP{},
-			"git":                   codegen.Git{},
-			"local":                 codegen.Local{},
-			"frontend":              codegen.Frontend{},
-			"run":                   codegen.Run{},
-			"env":                   codegen.Env{},
-			"dir":                   codegen.Dir{},
-			"user":                  codegen.User{},
-			"mkdir":                 codegen.Mkdir{},
-			"mkfile":                codegen.Mkfile{},
-			"rm":                    codegen.Rm{},
-			"copy":                  codegen.Copy{},
-			"merge":                 codegen.Merge{},
-			"diff":                  codegen.Diff{},
-			"entrypoint":            codegen.Entrypoint{},
-			"cmd":                   codegen.Cmd{},
-			"label":                 codegen.Label{},
-			"expose":                codegen.Expose{},
-			"volumes":               codegen.Volumes{},
-			"stopSignal":            codegen.StopSignal{},
-			"dockerPush":            codegen.DockerPush{},
-			"dockerLoad":            codegen.DockerLoad{},
-			"download":              codegen.Download{},
-			"downloadTarball":       codegen.DownloadTarball{},
-			"downloadOCITarball":    codegen.DownloadOCITarball{},
-			"downloadDockerTarball": codegen.DownloadDockerTarball{},
-			"breakpoint":            codegen.SetBreakpoint{},
-		},
-		parser.String: {
-			"format":    codegen.Format{},
-			"template":  codegen.Template{},
-			"manifest":  codegen.Manifest{},
-			"localArch": codegen.LocalArch{},
-			"localOs":   codegen.LocalOS{},
-			"localCwd":  codegen.LocalCwd{},
-			"localEnv":  codegen.LocalEnv{},
-			"localRun":  codegen.LocalRun{},
-		},
-		parser.Pipeline: {
-			"stage":    codegen.Stage{},
-			"parallel": codegen.Stage{},
-		},
-		"option::image": {
-			"resolve":  codegen.Resolve{},
-			"platform": codegen.Platform{},
-		},
-		"option::http": {
-			"checksum": codegen.Checksum{},
-			"chmod":    codegen.Chmod{},
-			"filename": codegen.Filename{},
-		},
-		"option::git": {
-			"keepGitDir": codegen.KeepGitDir{},
-		},
-		"option::local": {
-			"includePatterns": codegen.IncludePatterns{},
-			"excludePatterns": codegen.ExcludePatterns{},
-			"followPaths":     codegen.FollowPaths{},
-		},
-		"option::frontend": {
-			"input": codegen.FrontendInput{},
-			"opt":   codegen.FrontendOpt{},
-		},
-		"option::run": {
-			"readonlyRootfs": codegen.ReadonlyRootfs{},
-			"env":            codegen.RunEnv{},
-			"dir":            codegen.RunDir{},
-			"user":           codegen.RunUser{},
-			"ignoreCache":    codegen.IgnoreCache{},
-			"network":        codegen.Network{},
-			"security":       codegen.Security{},
-			"shlex":          codegen.Shlex{},
-			"host":           codegen.Host{},
-			"ssh":            codegen.SSH{},
-			"forward":        codegen.Forward{},
-			"secret":         codegen.Secret{},
-			"mount":          codegen.Mount{},
-			"breakpoint":     codegen.RunBreakpoint{},
-		},
-		"option::ssh": {
-			"target":     codegen.MountTarget{},
-			"uid":        codegen.UID{},
-			"gid":        codegen.GID{},
-			"mode":       codegen.UtilChmod{},
-			"localPaths": codegen.LocalPaths{},
-		},
-		"option::secret": {
-			"uid":             codegen.UID{},
-			"gid":             codegen.GID{},
-			"mode":            codegen.UtilChmod{},
-			"includePatterns": codegen.SecretIncludePatterns{},
-			"excludePatterns": codegen.SecretExcludePatterns{},
-		},
-		"option::mount": {
-			"readonly":   codegen.Readonly{},
-			"tmpfs":      codegen.Tmpfs{},
-			"sourcePath": codegen.SourcePath{},
-			"cache":      codegen.Cache{},
-		},
-		"option::mkdir": {
-			"createParents": codegen.CreateParents{},
-			"chown":         codegen.Chown{},
-			"createdTime":   codegen.CreatedTime{},
-		},
-		"option::mkfile": {
-			"chown":       codegen.Chown{},
-			"createdTime": codegen.CreatedTime{},
-		},
-		"option::rm": {
-			"allowNotFound": codegen.AllowNotFound{},
-			"allowWildcard": codegen.AllowWildcard{},
-		},
-		"option::copy": {
-			"followSymlinks":     codegen.FollowSymlinks{},
-			"contentsOnly":       codegen.ContentsOnly{},
-			"unpack":             codegen.Unpack{},
-			"createDestPath":     codegen.CreateDestPath{},
-			"allowWildcard":      codegen.CopyAllowWildcard{},
-			"allowEmptyWildcard": codegen.AllowEmptyWildcard{},
-			"chown":              codegen.UtilChown{},
-			"chmod":              codegen.UtilChmod{},
-			"createdTime":        codegen.UtilCreatedTime{},
-			"includePatterns":    codegen.CopyIncludePatterns{},
-			"excludePatterns":    codegen.CopyExcludePatterns{},
-		},
-		"option::localRun": {
-			"ignoreError":   codegen.IgnoreError{},
-			"onlyStderr":    codegen.OnlyStderr{},
-			"includeStderr": codegen.IncludeStderr{},
-			"shlex":         codegen.Shlex{},
-		},
-		"option::template": {
-			"stringField": codegen.StringField{},
-		},
-		"option::manifest": {
-			"platform": codegen.Platform{},
-		},
-	}
 )
 
 func init() {
@@ -167,41 +21,6 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-
-	err = initCallables()
-	if err != nil {
-		panic(err)
-	}
-}
-
-func initCallables() error {
-	protoCall, ok := reflect.TypeOf(codegen.Prototype{}).MethodByName("Call")
-	if !ok {
-		return fmt.Errorf("Prototype has no Call method")
-	}
-
-	// Build prototype signature.
-	for i := 1; i < protoCall.Type.NumIn(); i++ {
-		codegen.PrototypeIn = append(codegen.PrototypeIn, protoCall.Type.In(i))
-	}
-	for i := 0; i < protoCall.Type.NumOut(); i++ {
-		codegen.PrototypeOut = append(codegen.PrototypeOut, protoCall.Type.Out(i))
-	}
-
-	// Type check all the builtin functions.
-	var errs []string
-	for _, byKind := range Callables {
-		for _, callable := range byKind {
-			err := CheckPrototype(callable)
-			if err != nil {
-				errs = append(errs, err.Error())
-			}
-		}
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf(strings.Join(errs, "\n"))
-	}
-	return nil
 }
 
 func initSources() (err error) {
@@ -221,49 +40,4 @@ func Sources() *filebuffer.Sources {
 	sources := filebuffer.NewSources()
 	sources.Set(FileBuffer.Filename(), FileBuffer)
 	return sources
-}
-
-func CheckPrototype(callable parser.Callable) error {
-	c := reflect.ValueOf(callable).MethodByName("Call")
-
-	var (
-		ins  []reflect.Type
-		outs []reflect.Type
-	)
-	for i := 0; i < c.Type().NumIn(); i++ {
-		ins = append(ins, c.Type().In(i))
-	}
-	for i := 0; i < c.Type().NumOut(); i++ {
-		outs = append(outs, c.Type().Out(i))
-	}
-
-	err := fmt.Errorf(
-		"expected (%s).Call(%s)(%s) to match Call(%s)(%s)",
-		reflect.TypeOf(callable),
-		ins,
-		outs,
-		codegen.PrototypeIn,
-		codegen.PrototypeOut,
-	)
-
-	// Verify callable matches prototype signature.
-	if c.Type().NumIn() < len(codegen.PrototypeIn) || c.Type().NumOut() != len(codegen.PrototypeOut) {
-		return err
-	}
-	for i := 0; i < len(codegen.PrototypeIn); i++ {
-		param := ins[i]
-		if (param.Kind() == reflect.Interface && !param.Implements(codegen.PrototypeIn[i])) ||
-			(param.Kind() != reflect.Interface && param != codegen.PrototypeIn[i]) {
-			return err
-		}
-	}
-	for i := 0; i < len(codegen.PrototypeOut); i++ {
-		param := outs[i]
-		if (param.Kind() == reflect.Interface && !param.Implements(codegen.PrototypeOut[i])) ||
-			(param.Kind() != reflect.Interface && param != codegen.PrototypeOut[i]) {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/checker/builtin.go
+++ b/checker/builtin.go
@@ -26,15 +26,13 @@ func NewBuiltinScope(builtins builtin.BuiltinLookup) *parser.Scope {
 						Module:         builtin.Module,
 						Name:           fun.Name.String(),
 						FuncDeclByKind: make(map[parser.Kind]*parser.FuncDecl),
-						CallableByKind: make(map[parser.Kind]parser.Callable),
 					},
 				}
 			}
 
 			decl := obj.Node.(*parser.BuiltinDecl)
+			decl.Kinds = append(decl.Kinds, fun.Type.Kind)
 			decl.FuncDeclByKind[fun.Type.Kind] = fun
-			decl.CallableByKind[fun.Type.Kind] = builtin.Callables[fun.Type.Kind][fun.Name.Text]
-
 			scope.Insert(obj)
 		},
 	)

--- a/client.go
+++ b/client.go
@@ -1,0 +1,71 @@
+package hlb
+
+import (
+	"context"
+	"net"
+
+	"github.com/docker/buildx/store/storeutil"
+	"github.com/docker/buildx/util/imagetools"
+	dockercommand "github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/flags"
+	"github.com/moby/buildkit/client"
+	"github.com/openllb/hlb/codegen"
+	"github.com/openllb/hlb/solver"
+)
+
+// Client returns a BuildKit client specified by addr based on BuildKit's
+// connection helpers.
+//
+// If addr is empty, an attempt is made to connect to docker engine's embedded
+// BuildKit which supports a subset of the exporters and special `moby`
+// exporter.
+func Client(ctx context.Context, addr string) (*client.Client, context.Context, error) {
+	var (
+		dockerCli *dockercommand.DockerCli
+		auth      imagetools.Auth
+		err       error
+	)
+	// Attempt to connect to a healthy docker engine.
+	for _, f := range []func() error{
+		func() error {
+			dockerCli, err = dockercommand.NewDockerCli()
+			return err
+		},
+		func() error {
+			return dockerCli.Initialize(flags.NewClientOptions())
+		},
+		func() error {
+			_, err = dockerCli.Client().ServerVersion(ctx)
+			return err
+		},
+		func() error {
+			imageopt, err := storeutil.GetImageConfig(dockerCli, nil)
+			if err != nil {
+				return err
+			}
+			auth = imageopt.Auth
+			return nil
+		},
+	} {
+		err = f()
+		if err != nil {
+			break
+		}
+	}
+
+	// If addr is empty, connect to BuildKit using connection helpers.
+	if addr != "" {
+		ctx = codegen.WithDockerAPI(ctx, dockerCli.Client(), auth, err, false)
+		cln, err := solver.BuildkitClient(ctx, addr)
+		return cln, ctx, err
+	}
+
+	// Otherwise, connect to docker engine's embedded BuildKit.
+	ctx = codegen.WithDockerAPI(ctx, dockerCli.Client(), auth, err, true)
+	cln, err := client.New(ctx, "", client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return dockerCli.Client().DialHijack(ctx, "/grpc", "h2c", nil)
+	}), client.WithSessionDialer(func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
+		return dockerCli.Client().DialHijack(ctx, "/session", proto, meta)
+	}))
+	return cln, ctx, err
+}

--- a/cmd/hlb/command/context.go
+++ b/cmd/hlb/command/context.go
@@ -2,21 +2,12 @@ package command
 
 import (
 	"context"
-	"net"
 	"os"
 
-	"github.com/docker/buildx/store/storeutil"
-	"github.com/docker/buildx/util/imagetools"
-	dockercommand "github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/flags"
 	"github.com/logrusorgru/aurora"
 	isatty "github.com/mattn/go-isatty"
-	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/appcontext"
-	"github.com/openllb/hlb/codegen"
 	"github.com/openllb/hlb/diagnostic"
-	"github.com/openllb/hlb/solver"
-	cli "github.com/urfave/cli/v2"
 )
 
 func Context() context.Context {
@@ -25,55 +16,4 @@ func Context() context.Context {
 		ctx = diagnostic.WithColor(ctx, aurora.NewAurora(true))
 	}
 	return ctx
-}
-
-func Client(c *cli.Context) (*client.Client, context.Context, error) {
-	ctx := Context()
-
-	var (
-		dockerCli *dockercommand.DockerCli
-		auth      imagetools.Auth
-		err       error
-	)
-	for _, f := range []func() error{
-		func() error {
-			dockerCli, err = dockercommand.NewDockerCli()
-			return err
-		},
-		func() error {
-			return dockerCli.Initialize(flags.NewClientOptions())
-		},
-		func() error {
-			_, err = dockerCli.Client().ServerVersion(ctx)
-			return err
-		},
-		func() error {
-			imageopt, err := storeutil.GetImageConfig(dockerCli, nil)
-			if err != nil {
-				return err
-			}
-			auth = imageopt.Auth
-			return nil
-		},
-	} {
-		err = f()
-		if err != nil {
-			break
-		}
-	}
-
-	addr := c.String("addr")
-	if addr != "" {
-		ctx = codegen.WithDockerAPI(ctx, dockerCli.Client(), auth, err, false)
-		cln, err := solver.BuildkitClient(ctx, addr)
-		return cln, ctx, err
-	}
-
-	ctx = codegen.WithDockerAPI(ctx, dockerCli.Client(), auth, err, true)
-	cln, err := client.New(ctx, "", client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
-		return dockerCli.Client().DialHijack(ctx, "/grpc", "h2c", nil)
-	}), client.WithSessionDialer(func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
-		return dockerCli.Client().DialHijack(ctx, "/session", proto, meta)
-	}))
-	return cln, ctx, err
 }

--- a/cmd/hlb/command/langserver.go
+++ b/cmd/hlb/command/langserver.go
@@ -1,10 +1,10 @@
 package command
 
 import (
-	"context"
 	"log"
 	"os"
 
+	"github.com/openllb/hlb"
 	"github.com/openllb/hlb/langserver"
 	cli "github.com/urfave/cli/v2"
 )
@@ -27,9 +27,16 @@ var langserverCommand = &cli.Command{
 		defer f.Close()
 		log.SetOutput(f)
 
-		s := langserver.NewServer()
+		cln, ctx, err := hlb.Client(Context(), c.String("addr"))
+		if err != nil {
+			return err
+		}
 
-		ctx := context.Background()
-		return s.Listen(ctx, os.Stdin, os.Stdout)
+		s, err := langserver.NewServer(ctx, cln)
+		if err != nil {
+			return err
+		}
+
+		return s.Listen(os.Stdin, os.Stdout)
 	},
 }

--- a/cmd/hlb/command/lint.go
+++ b/cmd/hlb/command/lint.go
@@ -57,7 +57,7 @@ func Lint(ctx context.Context, r io.Reader, info LintInfo) error {
 		return err
 	}
 
-	err = linter.Lint(ctx, mod, linter.WithRecursive())
+	err = linter.Lint(ctx, mod)
 	if err != nil {
 		spans := diagnostic.Spans(err)
 		for _, span := range spans {

--- a/cmd/hlb/command/module.go
+++ b/cmd/hlb/command/module.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/client"
+	"github.com/openllb/hlb"
 	"github.com/openllb/hlb/builtin"
 	"github.com/openllb/hlb/checker"
 	"github.com/openllb/hlb/codegen"
@@ -45,7 +46,7 @@ var moduleVendorCommand = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		cln, ctx, err := Client(c)
+		cln, ctx, err := hlb.Client(Context(), c.String("addr"))
 		if err != nil {
 			return err
 		}
@@ -64,7 +65,7 @@ var moduleTidyCommand = &cli.Command{
 	Usage:     "add missing and remove unused modules",
 	ArgsUsage: "<*.hlb>",
 	Action: func(c *cli.Context) error {
-		cln, ctx, err := Client(c)
+		cln, ctx, err := hlb.Client(Context(), c.String("addr"))
 		if err != nil {
 			return err
 		}
@@ -88,7 +89,7 @@ var moduleTreeCommand = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		cln, ctx, err := Client(c)
+		cln, ctx, err := hlb.Client(Context(), c.String("addr"))
 		if err != nil {
 			return err
 		}
@@ -148,7 +149,7 @@ func Vendor(ctx context.Context, cln *client.Client, info VendorInfo) (err error
 		return err
 	}
 
-	_ = linter.Lint(ctx, mod, linter.WithRecursive())
+	_ = linter.Lint(ctx, mod)
 
 	err = checker.Check(mod)
 	if err != nil {
@@ -218,7 +219,7 @@ func findVendoredModule(errNotExist error, name string) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("ambiguous hlb module, specify more digest characters.")
 	}
 
-	return os.Open(filepath.Join(matchedModules[0], module.ModuleFilename))
+	return os.Open(filepath.Join(matchedModules[0], codegen.ModuleFilename))
 }
 
 type TreeInfo struct {
@@ -259,7 +260,7 @@ func Tree(ctx context.Context, cln *client.Client, info TreeInfo) (err error) {
 		return err
 	}
 
-	_ = linter.Lint(ctx, mod, linter.WithRecursive())
+	_ = linter.Lint(ctx, mod)
 
 	err = checker.Check(mod)
 	if err != nil {

--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -76,7 +76,7 @@ var runCommand = &cli.Command{
 		}
 		defer rc.Close()
 
-		cln, ctx, err := Client(c)
+		cln, ctx, err := hlb.Client(Context(), c.String("addr"))
 		if err != nil {
 			return err
 		}

--- a/codegen/builtin.go
+++ b/codegen/builtin.go
@@ -1,0 +1,236 @@
+package codegen
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/openllb/hlb/parser"
+)
+
+var (
+	Callables = map[parser.Kind]map[string]interface{}{
+		parser.Filesystem: {
+			"scratch":               Scratch{},
+			"image":                 Image{},
+			"http":                  HTTP{},
+			"git":                   Git{},
+			"local":                 Local{},
+			"frontend":              Frontend{},
+			"run":                   Run{},
+			"env":                   Env{},
+			"dir":                   Dir{},
+			"user":                  User{},
+			"mkdir":                 Mkdir{},
+			"mkfile":                Mkfile{},
+			"rm":                    Rm{},
+			"copy":                  Copy{},
+			"merge":                 Merge{},
+			"diff":                  Diff{},
+			"entrypoint":            Entrypoint{},
+			"cmd":                   Cmd{},
+			"label":                 Label{},
+			"expose":                Expose{},
+			"volumes":               Volumes{},
+			"stopSignal":            StopSignal{},
+			"dockerPush":            DockerPush{},
+			"dockerLoad":            DockerLoad{},
+			"download":              Download{},
+			"downloadTarball":       DownloadTarball{},
+			"downloadOCITarball":    DownloadOCITarball{},
+			"downloadDockerTarball": DownloadDockerTarball{},
+			"breakpoint":            SetBreakpoint{},
+		},
+		parser.String: {
+			"format":    Format{},
+			"template":  Template{},
+			"manifest":  Manifest{},
+			"localArch": LocalArch{},
+			"localOs":   LocalOS{},
+			"localCwd":  LocalCwd{},
+			"localEnv":  LocalEnv{},
+			"localRun":  LocalRun{},
+		},
+		parser.Pipeline: {
+			"stage":    Stage{},
+			"parallel": Stage{},
+		},
+		"option::image": {
+			"resolve":  Resolve{},
+			"platform": Platform{},
+		},
+		"option::http": {
+			"checksum": Checksum{},
+			"chmod":    Chmod{},
+			"filename": Filename{},
+		},
+		"option::git": {
+			"keepGitDir": KeepGitDir{},
+		},
+		"option::local": {
+			"includePatterns": IncludePatterns{},
+			"excludePatterns": ExcludePatterns{},
+			"followPaths":     FollowPaths{},
+		},
+		"option::frontend": {
+			"input": FrontendInput{},
+			"opt":   FrontendOpt{},
+		},
+		"option::run": {
+			"readonlyRootfs": ReadonlyRootfs{},
+			"env":            RunEnv{},
+			"dir":            RunDir{},
+			"user":           RunUser{},
+			"ignoreCache":    IgnoreCache{},
+			"network":        Network{},
+			"security":       Security{},
+			"shlex":          Shlex{},
+			"host":           Host{},
+			"ssh":            SSH{},
+			"forward":        Forward{},
+			"secret":         Secret{},
+			"mount":          Mount{},
+			"breakpoint":     RunBreakpoint{},
+		},
+		"option::ssh": {
+			"target":     MountTarget{},
+			"uid":        UID{},
+			"gid":        GID{},
+			"mode":       UtilChmod{},
+			"localPaths": LocalPaths{},
+		},
+		"option::secret": {
+			"uid":             UID{},
+			"gid":             GID{},
+			"mode":            UtilChmod{},
+			"includePatterns": SecretIncludePatterns{},
+			"excludePatterns": SecretExcludePatterns{},
+		},
+		"option::mount": {
+			"readonly":   Readonly{},
+			"tmpfs":      Tmpfs{},
+			"sourcePath": SourcePath{},
+			"cache":      Cache{},
+		},
+		"option::mkdir": {
+			"createParents": CreateParents{},
+			"chown":         Chown{},
+			"createdTime":   CreatedTime{},
+		},
+		"option::mkfile": {
+			"chown":       Chown{},
+			"createdTime": CreatedTime{},
+		},
+		"option::rm": {
+			"allowNotFound": AllowNotFound{},
+			"allowWildcard": AllowWildcard{},
+		},
+		"option::copy": {
+			"followSymlinks":     FollowSymlinks{},
+			"contentsOnly":       ContentsOnly{},
+			"unpack":             Unpack{},
+			"createDestPath":     CreateDestPath{},
+			"allowWildcard":      CopyAllowWildcard{},
+			"allowEmptyWildcard": AllowEmptyWildcard{},
+			"chown":              UtilChown{},
+			"chmod":              UtilChmod{},
+			"createdTime":        UtilCreatedTime{},
+			"includePatterns":    CopyIncludePatterns{},
+			"excludePatterns":    CopyExcludePatterns{},
+		},
+		"option::localRun": {
+			"ignoreError":   IgnoreError{},
+			"onlyStderr":    OnlyStderr{},
+			"includeStderr": IncludeStderr{},
+			"shlex":         Shlex{},
+		},
+		"option::template": {
+			"stringField": StringField{},
+		},
+		"option::manifest": {
+			"platform": Platform{},
+		},
+	}
+)
+
+func init() {
+	err := initCallables()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func initCallables() error {
+	protoCall, ok := reflect.TypeOf(Prototype{}).MethodByName("Call")
+	if !ok {
+		return fmt.Errorf("Prototype has no Call method")
+	}
+
+	// Build prototype signature.
+	for i := 1; i < protoCall.Type.NumIn(); i++ {
+		PrototypeIn = append(PrototypeIn, protoCall.Type.In(i))
+	}
+	for i := 0; i < protoCall.Type.NumOut(); i++ {
+		PrototypeOut = append(PrototypeOut, protoCall.Type.Out(i))
+	}
+
+	// Type check all the builtin functions.
+	var errs []string
+	for _, byKind := range Callables {
+		for _, callable := range byKind {
+			err := CheckPrototype(callable)
+			if err != nil {
+				errs = append(errs, err.Error())
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf(strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+func CheckPrototype(callable interface{}) error {
+	c := reflect.ValueOf(callable).MethodByName("Call")
+
+	var (
+		ins  []reflect.Type
+		outs []reflect.Type
+	)
+	for i := 0; i < c.Type().NumIn(); i++ {
+		ins = append(ins, c.Type().In(i))
+	}
+	for i := 0; i < c.Type().NumOut(); i++ {
+		outs = append(outs, c.Type().Out(i))
+	}
+
+	err := fmt.Errorf(
+		"expected (%s).Call(%s)(%s) to match Call(%s)(%s)",
+		reflect.TypeOf(callable),
+		ins,
+		outs,
+		PrototypeIn,
+		PrototypeOut,
+	)
+
+	// Verify callable matches prototype signature.
+	if c.Type().NumIn() < len(PrototypeIn) || c.Type().NumOut() != len(PrototypeOut) {
+		return err
+	}
+	for i := 0; i < len(PrototypeIn); i++ {
+		param := ins[i]
+		if (param.Kind() == reflect.Interface && !param.Implements(PrototypeIn[i])) ||
+			(param.Kind() != reflect.Interface && param != PrototypeIn[i]) {
+			return err
+		}
+	}
+	for i := 0; i < len(PrototypeOut); i++ {
+		param := outs[i]
+		if (param.Kind() == reflect.Interface && !param.Implements(PrototypeOut[i])) ||
+			(param.Kind() != reflect.Interface && param != PrototypeOut[i]) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/codegen/resolver.go
+++ b/codegen/resolver.go
@@ -9,10 +9,23 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
 	digest "github.com/opencontainers/go-digest"
+	"github.com/openllb/hlb/parser"
 	"github.com/openllb/hlb/pkg/llbutil"
 	"github.com/openllb/hlb/solver"
 	"golang.org/x/sync/errgroup"
 )
+
+const (
+	// ModuleFilename is the filename of the HLB module expected to be in the
+	// solved filesystem provided to the import declaration.
+	ModuleFilename = "module.hlb"
+)
+
+// Resolver resolves imports into a reader ready for parsing and checking.
+type Resolver interface {
+	// Resolve returns a reader for the HLB module and its compiled LLB.
+	Resolve(ctx context.Context, id *parser.ImportDecl, fs Filesystem) (parser.Directory, error)
+}
 
 func NewCachedImageResolver(cln *client.Client) llb.ImageMetaResolver {
 	return &cachedImageResolver{

--- a/errdefs/errors.go
+++ b/errdefs/errors.go
@@ -55,7 +55,10 @@ func WithDeprecated(mod *parser.Module, node parser.Node, format string, a ...in
 }
 
 func WithInternalErrorf(node parser.Node, format string, a ...interface{}) error {
-	return errors.WithStack(node.WithError(fmt.Errorf(format, a...)))
+	return node.WithError(
+		fmt.Errorf(format, a...),
+		node.Spanf(diagnostic.Primary, format, a...),
+	)
 }
 
 func WithInvalidCompileTarget(ident parser.Node) error {
@@ -224,14 +227,6 @@ func WithInvalidSharingMode(arg parser.Node, mode string, modes []string) error 
 	return arg.WithError(
 		fmt.Errorf("invalid cache sharing mode `%s`", mode),
 		arg.Spanf(diagnostic.Primary, "invalid sharing mode `%s`%s", mode, suggestion),
-	)
-}
-
-func WithImportWithinImport(ie, decl parser.Node) error {
-	return ie.WithError(
-		fmt.Errorf("cannot use import within import"),
-		ie.Spanf(diagnostic.Primary, "cannot use import within import"),
-		decl.Spanf(diagnostic.Secondary, "imported here"),
 	)
 }
 

--- a/hlb.go
+++ b/hlb.go
@@ -22,7 +22,7 @@ func Compile(ctx context.Context, cln *client.Client, mod *parser.Module, target
 		return nil, err
 	}
 
-	err = linter.Lint(ctx, mod, linter.WithRecursive())
+	err = linter.Lint(ctx, mod)
 	if err != nil {
 		for _, span := range diagnostic.Spans(err) {
 			fmt.Fprintln(os.Stderr, span.Pretty(ctx))
@@ -39,18 +39,7 @@ func Compile(ctx context.Context, cln *client.Client, mod *parser.Module, target
 		return nil, err
 	}
 
-	res, err := module.NewLocalResolved(mod)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Close()
-
-	err = module.ResolveGraph(ctx, cln, resolver, res, mod, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	cg, err := codegen.New(cln, opts...)
+	cg, err := codegen.New(cln, resolver, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/parser/scope.go
+++ b/parser/scope.go
@@ -61,7 +61,9 @@ func (s *Scope) Insert(obj *Object) {
 
 // Root returns the outer-most scope.
 func (s *Scope) Root() *Scope {
-	if s.Outer == nil {
+	// Outer-most scope is the one right before a global scope of all the
+	// builtins, which doesn't have a node defined.
+	if s.Outer.Node == nil {
 		return s
 	}
 	return s.Outer.Root()


### PR DESCRIPTION
- Previously, all `ImportDecl` in the AST are crawled and resolved before codegen even begins, even if they are not been used, and also disallows imports in imports since it was a one-pass.
- Imports are now emitted dynamically during codegen, making them (1) lazy, (2) recursive, allowing you to use imports within imports.
- Example, running `hlb run -t lint` no longer pulls in `image("openllb/go.hlb")` because its code path doesn't depend on the import even if the module does.

## Implementation notes
- Imports are evaluated before call{stmt,expr} arguments are evaluated because we need the type information for its arguments. The signatures are now embedded in the `(parser.Call{Stmt,Expr}).Signature` during `checker` for easy access.
- Codegen no longer needs to guess the arg types for `(*CodeGen).Evaluate` since it has access to signatures.
- Refactor `module.Resolver` to `codegen.Resolver`
- Refactor `module.Resolved` to `parser.Directory`
- Refactor `cmd/hlb/command/context.go` client to `client.go` for re-use in `langserver`
- Once import is resolved, changed `obj.Data = imod.Scope` to `obj.Data = imod`, since we need access to both scope and directory interface.
- `Callable` and `BuiltinDecl` were refactored around due to golang import cycles
- Import related tests moved from `checker_test` to `codegen_test`
- Linter recursive removed because its already recursive in codegen's dynamic imports
- Move lint tests to `linter_test`, updated `checker_test` and `codegen_test` so they don't expect lint transforms