### PR TITLE
Refactor parser into parser and ast packages

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"strings"
 
-	"github.com/openllb/hlb/diagnostic"
 	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/parser/ast"
 	"github.com/openllb/hlb/pkg/filebuffer"
 	"github.com/pkg/errors"
 )
 
 var (
-	Module *parser.Module
+	Module *ast.Module
 
 	FileBuffer *filebuffer.FileBuffer
 )
@@ -24,7 +24,7 @@ func init() {
 }
 
 func initSources() (err error) {
-	ctx := diagnostic.WithSources(context.Background(), filebuffer.NewSources())
+	ctx := filebuffer.WithBuffers(context.Background(), filebuffer.NewBuffers())
 	Module, err = parser.Parse(ctx, &parser.NamedReader{
 		Reader: strings.NewReader(Reference),
 		Value:  "<builtin>",
@@ -32,12 +32,12 @@ func initSources() (err error) {
 	if err != nil {
 		return errors.Wrapf(err, "failed to initialize filebuffer for builtins")
 	}
-	FileBuffer = diagnostic.Sources(ctx).Get(Module.Pos.Filename)
+	FileBuffer = filebuffer.Buffers(ctx).Get(Module.Pos.Filename)
 	return
 }
 
-func Sources() *filebuffer.Sources {
-	sources := filebuffer.NewSources()
-	sources.Set(FileBuffer.Filename(), FileBuffer)
-	return sources
+func Buffers() *filebuffer.BufferLookup {
+	buffers := filebuffer.NewBuffers()
+	buffers.Set(FileBuffer.Filename(), FileBuffer)
+	return buffers
 }

--- a/builtin/gen/documentation.go
+++ b/builtin/gen/documentation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openllb/doxygen-parser/doxygen"
 	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/parser/ast"
 )
 
 // Documentation contains all the builtin functions defined for HLB.
@@ -126,7 +127,7 @@ func GenerateDocumentation(ctx context.Context, r io.Reader) (*Documentation, er
 			funcDoc.Doc = strings.TrimSpace(group.Doc)
 		}
 
-		if fun.Type.Kind.Primary() == parser.Option {
+		if fun.Type.Kind.Primary() == ast.Option {
 			subtype := string(fun.Type.Kind.Secondary())
 			optionsByFunc[subtype] = append(optionsByFunc[subtype], funcDoc)
 		}

--- a/builtin/lookup.go
+++ b/builtin/lookup.go
@@ -2,10 +2,10 @@
 
 package builtin
 
-import "github.com/openllb/hlb/parser"
+import "github.com/openllb/hlb/parser/ast"
 
 type BuiltinLookup struct {
-	ByKind map[parser.Kind]LookupByKind
+	ByKind map[ast.Kind]LookupByKind
 }
 
 type LookupByKind struct {
@@ -13,678 +13,678 @@ type LookupByKind struct {
 }
 
 type FuncLookup struct {
-	Params  []*parser.Field
-	Effects []*parser.Field
+	Params  []*ast.Field
+	Effects []*ast.Field
 }
 
 var (
 	Lookup = BuiltinLookup{
-		ByKind: map[parser.Kind]LookupByKind{
-			parser.Filesystem: {
+		ByKind: map[ast.Kind]LookupByKind{
+			ast.Filesystem: {
 				Func: map[string]FuncLookup{
 					"scratch": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"image": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "ref", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "ref", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"http": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "url", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "url", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"git": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "remote", false),
-							parser.NewField(parser.String, "ref", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "remote", false),
+							ast.NewField(ast.String, "ref", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"local": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "path", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "path", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"frontend": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "source", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "source", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"shell": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "arg", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "arg", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"run": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "arg", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "arg", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"env": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "key", false),
-							parser.NewField(parser.String, "value", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "key", false),
+							ast.NewField(ast.String, "value", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"dir": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "path", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "path", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"user": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "name", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "name", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"mkdir": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "path", false),
-							parser.NewField(parser.Int, "filemode", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "path", false),
+							ast.NewField(ast.Int, "filemode", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"mkfile": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "path", false),
-							parser.NewField(parser.Int, "filemode", false),
-							parser.NewField(parser.String, "content", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "path", false),
+							ast.NewField(ast.Int, "filemode", false),
+							ast.NewField(ast.String, "content", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"rm": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "path", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "path", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"copy": {
-						Params: []*parser.Field{
-							parser.NewField(parser.Filesystem, "input", false),
-							parser.NewField(parser.String, "src", false),
-							parser.NewField(parser.String, "dst", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.Filesystem, "input", false),
+							ast.NewField(ast.String, "src", false),
+							ast.NewField(ast.String, "dst", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"merge": {
-						Params: []*parser.Field{
-							parser.NewField(parser.Filesystem, "inputs", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.Filesystem, "inputs", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"diff": {
-						Params: []*parser.Field{
-							parser.NewField(parser.Filesystem, "base", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.Filesystem, "base", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"dockerPush": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "ref", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "ref", false),
 						},
-						Effects: []*parser.Field{
-							parser.NewField(parser.String, "digest", false),
+						Effects: []*ast.Field{
+							ast.NewField(ast.String, "digest", false),
 						},
 					},
 					"dockerLoad": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "ref", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "ref", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"download": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "localPath", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "localPath", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"downloadTarball": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "localPath", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "localPath", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"downloadOCITarball": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "localPath", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "localPath", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"downloadDockerTarball": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "localPath", false),
-							parser.NewField(parser.String, "ref", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "localPath", false),
+							ast.NewField(ast.String, "ref", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"entrypoint": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "args", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "args", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"cmd": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "args", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "args", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"label": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "key", false),
-							parser.NewField(parser.String, "value", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "key", false),
+							ast.NewField(ast.String, "value", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"expose": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "ports", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "ports", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"volumes": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "mountpoints", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "mountpoints", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"stopSignal": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "signal", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "signal", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"breakpoint": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "command", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "command", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::copy": {
 				Func: map[string]FuncLookup{
 					"followSymlinks": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"contentsOnly": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"unpack": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"createDestPath": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"allowWildcard": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"allowEmptyWildcard": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"chown": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "owner", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "owner", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"chmod": {
-						Params: []*parser.Field{
-							parser.NewField(parser.Int, "filemode", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.Int, "filemode", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"createdTime": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "created", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "created", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"includePatterns": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "pattern", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "pattern", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"excludePatterns": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "pattern", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "pattern", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::frontend": {
 				Func: map[string]FuncLookup{
 					"input": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "key", false),
-							parser.NewField(parser.Filesystem, "value", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "key", false),
+							ast.NewField(ast.Filesystem, "value", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"opt": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "key", false),
-							parser.NewField(parser.String, "value", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "key", false),
+							ast.NewField(ast.String, "value", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::git": {
 				Func: map[string]FuncLookup{
 					"keepGitDir": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::http": {
 				Func: map[string]FuncLookup{
 					"checksum": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "digest", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "digest", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"chmod": {
-						Params: []*parser.Field{
-							parser.NewField(parser.Int, "filemode", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.Int, "filemode", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"filename": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "name", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "name", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::image": {
 				Func: map[string]FuncLookup{
 					"resolve": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"platform": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "os", false),
-							parser.NewField(parser.String, "arch", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "os", false),
+							ast.NewField(ast.String, "arch", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::local": {
 				Func: map[string]FuncLookup{
 					"includePatterns": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "pattern", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "pattern", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"excludePatterns": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "pattern", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "pattern", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"followPaths": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "path", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "path", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::localRun": {
 				Func: map[string]FuncLookup{
 					"ignoreError": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"includeStderr": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"onlyStderr": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"shlex": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::manifest": {
 				Func: map[string]FuncLookup{
 					"platform": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "os", false),
-							parser.NewField(parser.String, "arch", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "os", false),
+							ast.NewField(ast.String, "arch", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::mkdir": {
 				Func: map[string]FuncLookup{
 					"createParents": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"chown": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "owner", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "owner", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"createdTime": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "created", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "created", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::mkfile": {
 				Func: map[string]FuncLookup{
 					"chown": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "owner", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "owner", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"createdTime": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "created", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "created", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::mount": {
 				Func: map[string]FuncLookup{
 					"readonly": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"tmpfs": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"sourcePath": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "path", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "path", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"cache": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "cacheid", false),
-							parser.NewField(parser.String, "sharingmode", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "cacheid", false),
+							ast.NewField(ast.String, "sharingmode", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::rm": {
 				Func: map[string]FuncLookup{
 					"allowNotFound": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"allowWildcard": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::run": {
 				Func: map[string]FuncLookup{
 					"readonlyRootfs": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"env": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "key", false),
-							parser.NewField(parser.String, "value", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "key", false),
+							ast.NewField(ast.String, "value", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"dir": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "path", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "path", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"user": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "name", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "name", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"ignoreCache": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"network": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "networkmode", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "networkmode", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"security": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "securitymode", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "securitymode", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"shlex": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"host": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "hostname", false),
-							parser.NewField(parser.String, "address", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "hostname", false),
+							ast.NewField(ast.String, "address", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"ssh": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"forward": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "src", false),
-							parser.NewField(parser.String, "dest", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "src", false),
+							ast.NewField(ast.String, "dest", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"secret": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "localPath", false),
-							parser.NewField(parser.String, "mountPoint", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "localPath", false),
+							ast.NewField(ast.String, "mountPoint", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"mount": {
-						Params: []*parser.Field{
-							parser.NewField(parser.Filesystem, "input", false),
-							parser.NewField(parser.String, "mountPoint", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.Filesystem, "input", false),
+							ast.NewField(ast.String, "mountPoint", false),
 						},
-						Effects: []*parser.Field{
-							parser.NewField(parser.Filesystem, "target", false),
+						Effects: []*ast.Field{
+							ast.NewField(ast.Filesystem, "target", false),
 						},
 					},
 					"breakpoint": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "command", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "command", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::secret": {
 				Func: map[string]FuncLookup{
 					"uid": {
-						Params: []*parser.Field{
-							parser.NewField(parser.Int, "id", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.Int, "id", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"gid": {
-						Params: []*parser.Field{
-							parser.NewField(parser.Int, "id", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.Int, "id", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"mode": {
-						Params: []*parser.Field{
-							parser.NewField(parser.Int, "filemode", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.Int, "filemode", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"includePatterns": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "pattern", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "pattern", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"excludePatterns": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "pattern", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "pattern", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::ssh": {
 				Func: map[string]FuncLookup{
 					"target": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "mountPoint", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "mountPoint", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"localPaths": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "path", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "path", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"uid": {
-						Params: []*parser.Field{
-							parser.NewField(parser.Int, "id", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.Int, "id", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"gid": {
-						Params: []*parser.Field{
-							parser.NewField(parser.Int, "id", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.Int, "id", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"mode": {
-						Params: []*parser.Field{
-							parser.NewField(parser.Int, "filemode", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.Int, "filemode", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"option::template": {
 				Func: map[string]FuncLookup{
 					"stringField": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "name", false),
-							parser.NewField(parser.String, "value", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "name", false),
+							ast.NewField(ast.String, "value", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
 			"pipeline": {
 				Func: map[string]FuncLookup{
 					"stage": {
-						Params: []*parser.Field{
-							parser.NewField("pipeline", "pipelines", true),
+						Params: []*ast.Field{
+							ast.NewField("pipeline", "pipelines", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},
-			parser.String: {
+			ast.String: {
 				Func: map[string]FuncLookup{
 					"format": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "formatString", false),
-							parser.NewField(parser.String, "values", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "formatString", false),
+							ast.NewField(ast.String, "values", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"localArch": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"localCwd": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"localEnv": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "key", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "key", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"localOs": {
-						Params:  []*parser.Field{},
-						Effects: []*parser.Field{},
+						Params:  []*ast.Field{},
+						Effects: []*ast.Field{},
 					},
 					"localRun": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "command", false),
-							parser.NewField(parser.String, "args", true),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "command", false),
+							ast.NewField(ast.String, "args", true),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 					"manifest": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "ref", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "ref", false),
 						},
-						Effects: []*parser.Field{
-							parser.NewField(parser.String, "digest", false),
-							parser.NewField(parser.String, "config", false),
-							parser.NewField(parser.String, "index", false),
+						Effects: []*ast.Field{
+							ast.NewField(ast.String, "digest", false),
+							ast.NewField(ast.String, "config", false),
+							ast.NewField(ast.String, "index", false),
 						},
 					},
 					"template": {
-						Params: []*parser.Field{
-							parser.NewField(parser.String, "text", false),
+						Params: []*ast.Field{
+							ast.NewField(ast.String, "text", false),
 						},
-						Effects: []*parser.Field{},
+						Effects: []*ast.Field{},
 					},
 				},
 			},

--- a/checker/builtin.go
+++ b/checker/builtin.go
@@ -2,7 +2,7 @@ package checker
 
 import (
 	"github.com/openllb/hlb/builtin"
-	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/parser/ast"
 )
 
 // GlobalScope is a scope containing references to all builtins.
@@ -14,23 +14,23 @@ const (
 
 // NewBuiltinScope returns a new scope containing synthetic FuncDecl Objects for
 // builtins.
-func NewBuiltinScope(builtins builtin.BuiltinLookup) *parser.Scope {
-	scope := parser.NewScope(nil, nil)
-	parser.Match(builtin.Module, parser.MatchOpts{},
-		func(fun *parser.FuncDecl) {
+func NewBuiltinScope(builtins builtin.BuiltinLookup) *ast.Scope {
+	scope := ast.NewScope(nil, nil)
+	ast.Match(builtin.Module, ast.MatchOpts{},
+		func(fun *ast.FuncDecl) {
 			obj := scope.Lookup(fun.Name.Text)
 			if obj == nil {
-				obj = &parser.Object{
+				obj = &ast.Object{
 					Ident: fun.Name,
-					Node: &parser.BuiltinDecl{
+					Node: &ast.BuiltinDecl{
 						Module:         builtin.Module,
 						Name:           fun.Name.String(),
-						FuncDeclByKind: make(map[parser.Kind]*parser.FuncDecl),
+						FuncDeclByKind: make(map[ast.Kind]*ast.FuncDecl),
 					},
 				}
 			}
 
-			decl := obj.Node.(*parser.BuiltinDecl)
+			decl := obj.Node.(*ast.BuiltinDecl)
 			decl.Kinds = append(decl.Kinds, fun.Type.Kind)
 			decl.FuncDeclByKind[fun.Type.Kind] = fun
 			scope.Insert(obj)

--- a/cmd/hlb/command/lint.go
+++ b/cmd/hlb/command/lint.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openllb/hlb/errdefs"
 	"github.com/openllb/hlb/linter"
 	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/pkg/filebuffer"
 	cli "github.com/urfave/cli/v2"
 )
 
@@ -46,7 +47,7 @@ type LintInfo struct {
 }
 
 func Lint(ctx context.Context, r io.Reader, info LintInfo) error {
-	ctx = diagnostic.WithSources(ctx, builtin.Sources())
+	ctx = filebuffer.WithBuffers(ctx, builtin.Buffers())
 	mod, err := parser.Parse(ctx, r)
 	if err != nil {
 		return err

--- a/cmd/hlb/command/module.go
+++ b/cmd/hlb/command/module.go
@@ -18,6 +18,8 @@ import (
 	"github.com/openllb/hlb/linter"
 	"github.com/openllb/hlb/module"
 	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/parser/ast"
+	"github.com/openllb/hlb/pkg/filebuffer"
 	"github.com/openllb/hlb/solver"
 	cli "github.com/urfave/cli/v2"
 	"github.com/xlab/treeprint"
@@ -138,7 +140,7 @@ func Vendor(ctx context.Context, cln *client.Client, info VendorInfo) (err error
 		err = errdefs.WithAbort(err, len(spans))
 	}()
 
-	ctx = diagnostic.WithSources(ctx, builtin.Sources())
+	ctx = filebuffer.WithBuffers(ctx, builtin.Buffers())
 	mod, err := parser.Parse(ctx, rc)
 	if err != nil {
 		return err
@@ -157,8 +159,8 @@ func Vendor(ctx context.Context, cln *client.Client, info VendorInfo) (err error
 	}
 
 	hasImports := false
-	parser.Match(mod, parser.MatchOpts{},
-		func(imp *parser.ImportDecl) {
+	ast.Match(mod, ast.MatchOpts{},
+		func(imp *ast.ImportDecl) {
 			hasImports = true
 		},
 	)
@@ -249,7 +251,7 @@ func Tree(ctx context.Context, cln *client.Client, info TreeInfo) (err error) {
 		err = errdefs.WithAbort(err, len(spans))
 	}()
 
-	ctx = diagnostic.WithSources(ctx, builtin.Sources())
+	ctx = filebuffer.WithBuffers(ctx, builtin.Buffers())
 	mod, err := parser.Parse(ctx, rc)
 	if err != nil {
 		return err

--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openllb/hlb/errdefs"
 	"github.com/openllb/hlb/local"
 	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/pkg/filebuffer"
 	"github.com/openllb/hlb/solver"
 	cli "github.com/urfave/cli/v2"
 	"github.com/xlab/treeprint"
@@ -209,7 +210,7 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo
 	// store Progress in context in case we need to synchronize output later
 	ctx = codegen.WithProgress(ctx, p)
 	ctx = codegen.WithMultiWriter(ctx, p.MultiWriter())
-	ctx = diagnostic.WithSources(ctx, builtin.Sources())
+	ctx = filebuffer.WithBuffers(ctx, builtin.Buffers())
 
 	defer func() {
 		if err == nil {

--- a/codegen/builtin.go
+++ b/codegen/builtin.go
@@ -5,12 +5,12 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/parser/ast"
 )
 
 var (
-	Callables = map[parser.Kind]map[string]interface{}{
-		parser.Filesystem: {
+	Callables = map[ast.Kind]map[string]interface{}{
+		ast.Filesystem: {
 			"scratch":               Scratch{},
 			"image":                 Image{},
 			"http":                  HTTP{},
@@ -41,7 +41,7 @@ var (
 			"downloadDockerTarball": DownloadDockerTarball{},
 			"breakpoint":            SetBreakpoint{},
 		},
-		parser.String: {
+		ast.String: {
 			"format":    Format{},
 			"template":  Template{},
 			"manifest":  Manifest{},
@@ -51,7 +51,7 @@ var (
 			"localEnv":  LocalEnv{},
 			"localRun":  LocalRun{},
 		},
-		parser.Pipeline: {
+		ast.Pipeline: {
 			"stage":    Stage{},
 			"parallel": Stage{},
 		},

--- a/codegen/builtin_option.go
+++ b/codegen/builtin_option.go
@@ -23,6 +23,7 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/openllb/hlb/errdefs"
 	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/parser/ast"
 	"github.com/openllb/hlb/pkg/llbutil"
 	"github.com/openllb/hlb/pkg/sockproxy"
 	"github.com/openllb/hlb/solver"
@@ -869,7 +870,7 @@ func (sp SourcePath) Call(ctx context.Context, cln *client.Client, val Value, op
 }
 
 type Cache struct {
-	parser.Node
+	ast.Node
 }
 
 func (c Cache) Call(ctx context.Context, cln *client.Client, val Value, opts Option, id, mode string) (Value, error) {

--- a/codegen/resolver.go
+++ b/codegen/resolver.go
@@ -9,7 +9,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/parser/ast"
 	"github.com/openllb/hlb/pkg/llbutil"
 	"github.com/openllb/hlb/solver"
 	"golang.org/x/sync/errgroup"
@@ -24,7 +24,7 @@ const (
 // Resolver resolves imports into a reader ready for parsing and checking.
 type Resolver interface {
 	// Resolve returns a reader for the HLB module and its compiled LLB.
-	Resolve(ctx context.Context, id *parser.ImportDecl, fs Filesystem) (parser.Directory, error)
+	Resolve(ctx context.Context, id *ast.ImportDecl, fs Filesystem) (ast.Directory, error)
 }
 
 func NewCachedImageResolver(cln *client.Client) llb.ImageMetaResolver {

--- a/codegen/value.go
+++ b/codegen/value.go
@@ -14,7 +14,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/parser/ast"
 	"github.com/openllb/hlb/pkg/llbutil"
 	"github.com/openllb/hlb/solver"
 	"github.com/xlab/treeprint"
@@ -100,7 +100,7 @@ func (r *register) Value() Value {
 }
 
 type Value interface {
-	Kind() parser.Kind
+	Kind() ast.Kind
 	Filesystem() (Filesystem, error)
 	String() (string, error)
 	Int() (int, error)
@@ -147,8 +147,8 @@ func validateState(st llb.State) error {
 
 type nilValue struct{}
 
-func (v *nilValue) Kind() parser.Kind {
-	return parser.None
+func (v *nilValue) Kind() ast.Kind {
+	return ast.None
 }
 
 func (v *nilValue) Filesystem() (Filesystem, error) {
@@ -179,8 +179,8 @@ type errorValue struct {
 	err error
 }
 
-func (v *errorValue) Kind() parser.Kind {
-	return parser.None
+func (v *errorValue) Kind() ast.Kind {
+	return ast.None
 }
 
 func (v *errorValue) Filesystem() (Filesystem, error) {
@@ -217,8 +217,8 @@ func ZeroValue(ctx context.Context) Value {
 	}
 }
 
-func (v *zeroValue) Kind() parser.Kind {
-	return parser.None
+func (v *zeroValue) Kind() ast.Kind {
+	return ast.None
 }
 
 func (v *zeroValue) Filesystem() (Filesystem, error) {
@@ -278,8 +278,8 @@ type fsValue struct {
 	fs Filesystem
 }
 
-func (v *fsValue) Kind() parser.Kind {
-	return parser.Filesystem
+func (v *fsValue) Kind() ast.Kind {
+	return ast.Filesystem
 }
 
 func (v *fsValue) Filesystem() (Filesystem, error) {
@@ -321,8 +321,8 @@ type stringValue struct {
 	str string
 }
 
-func (v *stringValue) Kind() parser.Kind {
-	return parser.String
+func (v *stringValue) Kind() ast.Kind {
+	return ast.String
 }
 
 func (v *stringValue) String() (string, error) {
@@ -346,8 +346,8 @@ type intValue struct {
 	i int
 }
 
-func (v *intValue) Kind() parser.Kind {
-	return parser.Int
+func (v *intValue) Kind() ast.Kind {
+	return ast.Int
 }
 
 func (v *intValue) Int() (int, error) {
@@ -367,8 +367,8 @@ type optValue struct {
 	opt Option
 }
 
-func (v *optValue) Kind() parser.Kind {
-	return parser.Option
+func (v *optValue) Kind() ast.Kind {
+	return ast.Option
 }
 
 func (v *optValue) Option() (Option, error) {
@@ -380,8 +380,8 @@ type reqValue struct {
 	req solver.Request
 }
 
-func (v *reqValue) Kind() parser.Kind {
-	return parser.Pipeline
+func (v *reqValue) Kind() ast.Kind {
+	return ast.Pipeline
 }
 
 func (v *reqValue) Request() (solver.Request, error) {

--- a/diagnostic/context.go
+++ b/diagnostic/context.go
@@ -4,25 +4,9 @@ import (
 	"context"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/openllb/hlb/pkg/filebuffer"
 )
 
-type (
-	sourcesKey struct{}
-	colorKey   struct{}
-)
-
-func WithSources(ctx context.Context, sources *filebuffer.Sources) context.Context {
-	return context.WithValue(ctx, sourcesKey{}, sources)
-}
-
-func Sources(ctx context.Context) *filebuffer.Sources {
-	sources, ok := ctx.Value(sourcesKey{}).(*filebuffer.Sources)
-	if !ok {
-		return filebuffer.NewSources()
-	}
-	return sources
-}
+type colorKey struct{}
 
 func WithColor(ctx context.Context, color aurora.Aurora) context.Context {
 	return context.WithValue(ctx, colorKey{}, color)

--- a/diagnostic/error.go
+++ b/diagnostic/error.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/solver/errdefs"
+	"github.com/openllb/hlb/pkg/filebuffer"
 	perrors "github.com/pkg/errors"
 )
 
@@ -46,7 +47,7 @@ func Spans(err error) (spans []*SpanError) {
 func Backtrace(ctx context.Context, err error) (spans []*SpanError) {
 	srcs := errdefs.Sources(err)
 	for i, src := range srcs {
-		fb := Sources(ctx).Get(src.Info.Filename)
+		fb := filebuffer.Buffers(ctx).Get(src.Info.Filename)
 		if fb != nil {
 			var msg string
 			if i == len(srcs)-1 {

--- a/diagnostic/span.go
+++ b/diagnostic/span.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alecthomas/participle/lexer"
 	"github.com/logrusorgru/aurora"
+	"github.com/openllb/hlb/pkg/filebuffer"
 )
 
 type Type int
@@ -81,7 +82,7 @@ func (se *SpanError) Pretty(ctx context.Context, opts ...PrettyOption) string {
 	var (
 		info    PrettyInfo
 		reports []string
-		sources = Sources(ctx)
+		files   = filebuffer.Buffers(ctx)
 		color   = Color(ctx)
 	)
 	for _, opt := range opts {
@@ -92,7 +93,7 @@ func (se *SpanError) Pretty(ctx context.Context, opts ...PrettyOption) string {
 
 	filenames, spansByFilename := se.groupAnnnotations()
 	for _, filename := range filenames {
-		fb := sources.Get(filename)
+		fb := files.Get(filename)
 
 		// Sort spans in the same module by line number.
 		spans := spansByFilename[filename]
@@ -258,7 +259,7 @@ func (se *SpanError) Pretty(ctx context.Context, opts ...PrettyOption) string {
 func (se *SpanError) maxLn(ctx context.Context, numContext int) int {
 	maxLn := 0
 	for _, span := range se.Spans {
-		fb := Sources(ctx).Get(span.Start.Filename)
+		fb := filebuffer.Buffers(ctx).Get(span.Start.Filename)
 		line := span.Start.Line + numContext
 		if line > fb.Len() {
 			line = fb.Len()

--- a/hlb.go
+++ b/hlb.go
@@ -12,11 +12,11 @@ import (
 	"github.com/openllb/hlb/diagnostic"
 	"github.com/openllb/hlb/linter"
 	"github.com/openllb/hlb/module"
-	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/parser/ast"
 	"github.com/openllb/hlb/solver"
 )
 
-func Compile(ctx context.Context, cln *client.Client, mod *parser.Module, targets []codegen.Target, opts ...codegen.CodeGenOption) (solver.Request, error) {
+func Compile(ctx context.Context, cln *client.Client, mod *ast.Module, targets []codegen.Target, opts ...codegen.CodeGenOption) (solver.Request, error) {
 	err := checker.SemanticPass(mod)
 	if err != nil {
 		return nil, err

--- a/module/tree.go
+++ b/module/tree.go
@@ -7,14 +7,14 @@ import (
 	"sync"
 
 	"github.com/moby/buildkit/client"
-	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/parser/ast"
 	"github.com/xlab/treeprint"
 )
 
 // NewTree resolves the import graph and returns a treeprint.Tree that can be
 // printed to display a visualization of the imports. Imports that transitively
 // import the same module will be duplicated in the tree.
-func NewTree(ctx context.Context, cln *client.Client, mod *parser.Module, long bool) (treeprint.Tree, error) {
+func NewTree(ctx context.Context, cln *client.Client, mod *ast.Module, long bool) (treeprint.Tree, error) {
 	resolver, err := NewResolver(cln)
 	if err != nil {
 		return nil, err
@@ -22,7 +22,7 @@ func NewTree(ctx context.Context, cln *client.Client, mod *parser.Module, long b
 
 	var (
 		tree         = treeprint.New()
-		nodeByModule = make(map[*parser.Module]treeprint.Tree)
+		nodeByModule = make(map[*ast.Module]treeprint.Tree)
 		mu           sync.Mutex
 	)
 

--- a/module/vendor.go
+++ b/module/vendor.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/moby/buildkit/client"
 	"github.com/openllb/hlb/codegen"
-	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/parser/ast"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -17,7 +17,7 @@ import (
 //
 // If tidy mode is enabled, vertices with digests that already exist in the
 // modules directory are skipped, and unused modules are pruned.
-func Vendor(ctx context.Context, cln *client.Client, mod *parser.Module, targets []string, tidy bool) error {
+func Vendor(ctx context.Context, cln *client.Client, mod *ast.Module, targets []string, tidy bool) error {
 	root := ModulesPath
 
 	var mu sync.Mutex

--- a/parser/ast/ast.go
+++ b/parser/ast/ast.go
@@ -1,4 +1,4 @@
-package parser
+package ast
 
 import (
 	"fmt"

--- a/parser/ast/deprecated.go
+++ b/parser/ast/deprecated.go
@@ -1,4 +1,4 @@
-package parser
+package ast
 
 import (
 	"github.com/alecthomas/participle/lexer"

--- a/parser/ast/kind_set.go
+++ b/parser/ast/kind_set.go
@@ -1,4 +1,4 @@
-package parser
+package ast
 
 import (
 	"sort"

--- a/parser/ast/scope.go
+++ b/parser/ast/scope.go
@@ -1,4 +1,4 @@
-package parser
+package ast
 
 import (
 	"sort"

--- a/parser/ast/unparse.go
+++ b/parser/ast/unparse.go
@@ -1,4 +1,4 @@
-package parser
+package ast
 
 import (
 	"fmt"

--- a/parser/ast/unparse_test.go
+++ b/parser/ast/unparse_test.go
@@ -1,7 +1,6 @@
-package parser
+package ast
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -659,9 +658,12 @@ func TestUnparse(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			file, err := Parse(context.Background(), strings.NewReader(cleanup(tc.input)))
+
+			mod := &Module{}
+			r := strings.NewReader(cleanup(tc.input))
+			err := Parser.Parse("", r, mod)
 			require.NoError(t, err)
-			require.Equal(t, cleanup(tc.expected), file.String())
+			require.Equal(t, cleanup(tc.expected), mod.String())
 		})
 	}
 }

--- a/parser/ast/walk.go
+++ b/parser/ast/walk.go
@@ -1,4 +1,4 @@
-package parser
+package ast
 
 import (
 	"fmt"

--- a/parser/directory.go
+++ b/parser/directory.go
@@ -1,0 +1,36 @@
+package parser
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	digest "github.com/opencontainers/go-digest"
+	"github.com/openllb/hlb/parser/ast"
+)
+
+type localDirectory struct {
+	root string
+	dgst digest.Digest
+}
+
+func NewLocalDirectory(root string, dgst digest.Digest) ast.Directory {
+	return &localDirectory{root, dgst}
+}
+
+func (r *localDirectory) Path() string {
+	return r.root
+}
+
+func (r *localDirectory) Digest() digest.Digest {
+	return r.dgst
+}
+
+func (r *localDirectory) Open(filename string) (io.ReadCloser, error) {
+	if filepath.IsAbs(filename) {
+		return os.Open(filename)
+	}
+	return os.Open(filepath.Join(r.root, filename))
+}
+
+func (r *localDirectory) Close() error { return nil }

--- a/parser/docstrings.go
+++ b/parser/docstrings.go
@@ -1,29 +1,31 @@
 package parser
 
+import "github.com/openllb/hlb/parser/ast"
+
 // AssignDocStrings assigns the comment group immediately before a function
 // declaration as the function's doc string.
-func AssignDocStrings(mod *Module) {
+func AssignDocStrings(mod *ast.Module) {
 	var (
-		lastCG *CommentGroup
+		lastCG *ast.CommentGroup
 	)
 
-	Match(mod, MatchOpts{},
-		func(decl *Decl) {
+	ast.Match(mod, ast.MatchOpts{},
+		func(decl *ast.Decl) {
 			if decl.Comments != nil {
 				lastCG = decl.Comments
 			}
 		},
-		func(fun *FuncDecl) {
+		func(fun *ast.FuncDecl) {
 			if lastCG != nil && lastCG.End().Line == fun.Pos.Line-1 {
 				fun.Doc = lastCG
 			}
 
 			if fun.Body != nil {
-				Match(fun.Body, MatchOpts{},
-					func(cg *CommentGroup) {
+				ast.Match(fun.Body, ast.MatchOpts{},
+					func(cg *ast.CommentGroup) {
 						lastCG = cg
 					},
-					func(call *CallStmt) {
+					func(call *ast.CallStmt) {
 						if lastCG != nil && lastCG.End().Line == call.Pos.Line-1 {
 							call.Doc = lastCG
 						}

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -4,38 +4,36 @@ import (
 	"context"
 	"errors"
 	"io"
-	"os"
 	"path/filepath"
 
 	"github.com/alecthomas/participle/lexer"
-	digest "github.com/opencontainers/go-digest"
-	"github.com/openllb/hlb/diagnostic"
+	"github.com/openllb/hlb/parser/ast"
 	"github.com/openllb/hlb/pkg/filebuffer"
 	"golang.org/x/sync/errgroup"
 )
 
-func Parse(ctx context.Context, r io.Reader) (*Module, error) {
+func Parse(ctx context.Context, r io.Reader) (*ast.Module, error) {
 	name := lexer.NameOfReader(r)
 	if name == "" {
 		name = "<stdin>"
 	}
 	r = &NewlinedReader{Reader: r}
 
-	mod := &Module{}
+	mod := &ast.Module{}
 	defer AssignDocStrings(mod)
 
-	sources := diagnostic.Sources(ctx)
-	if sources != nil {
+	files := filebuffer.Buffers(ctx)
+	if files != nil {
 		fb := filebuffer.New(name)
 		r = io.TeeReader(r, fb)
 		defer func() {
 			if mod.Pos.Filename != "" {
-				sources.Set(mod.Pos.Filename, fb)
+				files.Set(mod.Pos.Filename, fb)
 			}
 		}()
 	}
 
-	err := Parser.Parse(name, r, mod)
+	err := ast.Parser.Parse(name, r, mod)
 	if err != nil {
 		return nil, err
 	}
@@ -43,8 +41,8 @@ func Parse(ctx context.Context, r io.Reader) (*Module, error) {
 	return mod, nil
 }
 
-func ParseMultiple(ctx context.Context, rs []io.Reader) ([]*Module, error) {
-	mods := make([]*Module, len(rs))
+func ParseMultiple(ctx context.Context, rs []io.Reader) ([]*ast.Module, error) {
+	mods := make([]*ast.Module, len(rs))
 
 	var g errgroup.Group
 	for i, r := range rs {
@@ -102,29 +100,3 @@ func (nr *NewlinedReader) Read(p []byte) (n int, err error) {
 	}
 	return n, nil
 }
-
-type localDirectory struct {
-	root string
-	dgst digest.Digest
-}
-
-func NewLocalDirectory(root string, dgst digest.Digest) Directory {
-	return &localDirectory{root, dgst}
-}
-
-func (r *localDirectory) Path() string {
-	return r.root
-}
-
-func (r *localDirectory) Digest() digest.Digest {
-	return r.dgst
-}
-
-func (r *localDirectory) Open(filename string) (io.ReadCloser, error) {
-	if filepath.IsAbs(filename) {
-		return os.Open(filename)
-	}
-	return os.Open(filepath.Join(r.root, filename))
-}
-
-func (r *localDirectory) Close() error { return nil }


### PR DESCRIPTION
Sorry for the big diff, I keep running into module import cycles so I moved some parts of the `parser` package into `ast`, and `diagnostic.WithSources` to `filebuffer.WithBuffers`.

Mostly mechanical via `rg --files-with-matches "pattern" | xargs sd "pattern" "replace"`