### PR TITLE
Remove unnecessary Release method from solver.Progress

### DIFF
--- a/cmd/hlb/command/module.go
+++ b/cmd/hlb/command/module.go
@@ -175,7 +175,6 @@ func Vendor(ctx context.Context, cln *client.Client, info VendorInfo) (err error
 		return err
 	}
 	defer p.Wait()
-	defer p.Release()
 
 	ctx = codegen.WithMultiWriter(ctx, p.MultiWriter())
 	return module.Vendor(ctx, cln, mod, info.Targets, info.Tidy)
@@ -290,7 +289,6 @@ func Tree(ctx context.Context, cln *client.Client, info TreeInfo) (err error) {
 		return err
 	}
 	defer p.Wait()
-	defer p.Release()
 
 	ctx = codegen.WithMultiWriter(ctx, p.MultiWriter())
 	tree, err = module.NewTree(ctx, cln, mod, info.Long)

--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -256,7 +256,6 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo
 
 	solveReq, err := hlb.Compile(ctx, cln, mod, targets, opts...)
 	if err != nil {
-		p.Release()
 		perr := p.Wait()
 		// Ignore early exits from the debugger.
 		if err == codegen.ErrDebugExit {
@@ -266,7 +265,6 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo
 	}
 
 	if solveReq == nil || info.Tree {
-		p.Release()
 		err = p.Wait()
 		if err != nil {
 			return err
@@ -289,7 +287,6 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo
 	}
 
 	defer p.Wait()
-	defer p.Release()
 	return solveReq.Solve(ctx, cln, p.MultiWriter(), solveOpts...)
 }
 

--- a/solver/progress_test.go
+++ b/solver/progress_test.go
@@ -67,7 +67,6 @@ func TestProgress(t *testing.T) {
 					require.NoError(t, err)
 				}
 
-				p.Release()
 				err = p.Wait()
 				require.NoError(t, err)
 


### PR DESCRIPTION
Currently the `solver.Progress` api requires calling `p.Release` and then `p.Wait`. This is the same everywhere and we might as well just consolidate it as `p.Wait`.