### PR TITLE
Resolve import rel paths correctly in both local and remote imports

### DIFF
--- a/codegen/context.go
+++ b/codegen/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/docker/buildx/util/imagetools"
 	dockerclient "github.com/docker/docker/client"
@@ -32,6 +33,7 @@ type (
 	backtraceKey       struct{}
 	progressKey        struct{}
 	platformKey        struct{}
+	importPathKey      struct{}
 	dockerAPIKey       struct{}
 	debuggerKey        struct{}
 	globalSolveOptsKey struct{}
@@ -63,7 +65,7 @@ func ModuleDir(ctx context.Context) string {
 	if node == nil {
 		return ""
 	}
-	return filepath.Dir(node.Position().Filename)
+	return filepath.Dir(strings.TrimPrefix(node.Position().Filename, ImportPath(ctx)))
 }
 
 func WithBinding(ctx context.Context, binding *ast.Binding) context.Context {
@@ -205,6 +207,15 @@ func DefaultPlatform(ctx context.Context) specs.Platform {
 		return specs.Platform{OS: "linux", Architecture: runtime.GOARCH}
 	}
 	return platform
+}
+
+func WithImportPath(ctx context.Context, path string) context.Context {
+	return context.WithValue(ctx, importPathKey{}, path)
+}
+
+func ImportPath(ctx context.Context) string {
+	path, _ := ctx.Value(importPathKey{}).(string)
+	return path
 }
 
 type DockerAPIClient struct {

--- a/module/resolve.go
+++ b/module/resolve.go
@@ -189,8 +189,7 @@ type remoteDirectory struct {
 }
 
 func (r *remoteDirectory) Path() string {
-	// TODO: cache imports in home dir
-	return ""
+	return r.root
 }
 
 func (r *remoteDirectory) Digest() digest.Digest {
@@ -356,6 +355,7 @@ func resolveGraph(ctx context.Context, info *resolveGraphInfo, mod *ast.Module) 
 					}
 				}
 
+				ctx = codegen.WithImportPath(ctx, imod.Directory.Path())
 				return resolveGraph(ctx, info, imod)
 			})
 		},


### PR DESCRIPTION
Broken somewhat by #290

Even before that PR, relative paths in remote imports was still broken.

- `flightcontrol` cancels the context provided to its function callback once its executed, for remote imports we hold on to a gateway build to keep the refs for the import fs alive until codegen exits. This was switched to `singleflight` that doesn't have context cancellation.

## Regression

What was broken is best illustrated by an example:
```hlb
# ./build.hlb
import other from "./sub/other.hlb"
fs default() {
    other.build
}
```

```hlb
# ./sub/other.hlb
import common from "../common.hlb"
export build
fs build() {
    common.build
}
```

The content of `./common.hlb` doesn't matter.

When evaluating the line `import common from "../common.hlb"` we need to resolve `../common.hlb` relative to the `./sub` directory, this was fixed in this PR.

However, for remote imports this wasn't fixed yet.

## Context for remote imports
Remote imports need their filenames represented by some kind of unique path that is also understandable by humans. For this, the input digest is combined with the module path that imported it like so:

```hlb
# ./build.hlb
import other from image("other.hlb")
```

```hlb
# image("other.hlb")/module.hlb
export build
fs build() { ... }
```

Then the path will be computed as `build.hlb#other/module.hlb`. This is used for source mapping, and other things.

If `image("other.hlb")` imported `image("another.hlb")` then its path would be `build.hlb#other/module.hlb#another/module.hlb`.

However, when resolving relative directories for the purposes of opening files in this buildkit ref, it's true module directory is `/` the rootfs of the image. The PR introduces `codegen.WithImportPath` to capture this special prefix and trim it when computing `codegen.ModuleDir(ctx)`.