### PR TITLE
Refactor to allow extension of module uris

### DIFF
--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	err := run(os.Args[1], os.Args[2])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "docgen: %s", err)
+		fmt.Fprintf(os.Stderr, "docgen: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/hlb/command/format.go
+++ b/cmd/hlb/command/format.go
@@ -47,13 +47,13 @@ type FormatInfo struct {
 }
 
 func Format(ctx context.Context, rs []io.Reader, info FormatInfo) error {
-	modules, err := parser.ParseMultiple(ctx, rs)
+	mods, err := parser.ParseMultiple(ctx, rs)
 	if err != nil {
 		return err
 	}
 
 	if info.Write {
-		for i, mod := range modules {
+		for i, mod := range mods {
 			filename := lexer.NameOfReader(rs[i])
 			if filename == "" {
 				return fmt.Errorf("Unable to write, file name unavailable")
@@ -69,7 +69,7 @@ func Format(ctx context.Context, rs []io.Reader, info FormatInfo) error {
 			}
 		}
 	} else {
-		for _, mod := range modules {
+		for _, mod := range mods {
 			fmt.Printf("%s", mod)
 		}
 	}

--- a/cmd/hlb/command/lint.go
+++ b/cmd/hlb/command/lint.go
@@ -8,20 +8,19 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/openllb/hlb/builtin"
+	"github.com/moby/buildkit/client"
+	"github.com/openllb/hlb"
 	"github.com/openllb/hlb/checker"
 	"github.com/openllb/hlb/diagnostic"
 	"github.com/openllb/hlb/errdefs"
 	"github.com/openllb/hlb/linter"
-	"github.com/openllb/hlb/parser"
-	"github.com/openllb/hlb/pkg/filebuffer"
 	cli "github.com/urfave/cli/v2"
 )
 
 var lintCommand = &cli.Command{
 	Name:      "lint",
 	Usage:     "lints a hlb module",
-	ArgsUsage: "<*.hlb>",
+	ArgsUsage: "<uri>",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:  "fix",
@@ -29,26 +28,36 @@ var lintCommand = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		rc, err := ModuleReadCloser(c.Args().Slice())
+		uri := DefaultHLBFilename
+		if c.NArg() > 1 {
+			return fmt.Errorf("expected at most 1 arg but got %d", c.NArg())
+		} else if c.NArg() == 1 {
+			uri = c.Args().First()
+		}
+
+		cln, ctx, err := hlb.Client(Context(), c.String("addr"))
 		if err != nil {
 			return err
 		}
-		defer rc.Close()
+		ctx = hlb.WithDefaultContext(ctx, cln)
 
-		return Lint(Context(), rc, LintInfo{
+		return Lint(ctx, cln, uri, LintInfo{
 			Fix: c.Bool("fix"),
 		})
-
 	},
 }
 
 type LintInfo struct {
-	Fix bool
+	Fix   bool
+	Stdin io.Reader
 }
 
-func Lint(ctx context.Context, r io.Reader, info LintInfo) error {
-	ctx = filebuffer.WithBuffers(ctx, builtin.Buffers())
-	mod, err := parser.Parse(ctx, r)
+func Lint(ctx context.Context, cln *client.Client, uri string, info LintInfo) error {
+	if info.Stdin == nil {
+		info.Stdin = os.Stdin
+	}
+
+	mod, err := ParseModuleURI(ctx, cln, info.Stdin, uri)
 	if err != nil {
 		return err
 	}

--- a/cmd/hlb/command/module.go
+++ b/cmd/hlb/command/module.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/moby/buildkit/client"
 	"github.com/openllb/hlb"
-	"github.com/openllb/hlb/builtin"
 	"github.com/openllb/hlb/checker"
 	"github.com/openllb/hlb/codegen"
 	"github.com/openllb/hlb/diagnostic"
@@ -19,7 +18,6 @@ import (
 	"github.com/openllb/hlb/module"
 	"github.com/openllb/hlb/parser"
 	"github.com/openllb/hlb/parser/ast"
-	"github.com/openllb/hlb/pkg/filebuffer"
 	"github.com/openllb/hlb/solver"
 	cli "github.com/urfave/cli/v2"
 	"github.com/xlab/treeprint"
@@ -39,7 +37,7 @@ var moduleCommand = &cli.Command{
 var moduleVendorCommand = &cli.Command{
 	Name:      "vendor",
 	Usage:     "vendor a copy of imported modules",
-	ArgsUsage: "<*.hlb | module digest>",
+	ArgsUsage: "<uri|digest>",
 	Flags: []cli.Flag{
 		&cli.StringSliceFlag{
 			Name:    "target",
@@ -48,16 +46,22 @@ var moduleVendorCommand = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
+		uri := DefaultHLBFilename
+		if c.NArg() > 1 {
+			return fmt.Errorf("expected at most 1 arg but got %d", c.NArg())
+		} else if c.NArg() == 1 {
+			uri = c.Args().First()
+		}
+
 		cln, ctx, err := hlb.Client(Context(), c.String("addr"))
 		if err != nil {
 			return err
 		}
+		ctx = hlb.WithDefaultContext(ctx, cln)
 
-		return Vendor(ctx, cln, VendorInfo{
-			Args:      c.Args().Slice(),
-			Targets:   c.StringSlice("target"),
-			Tidy:      false,
-			ErrOutput: os.Stderr,
+		return Vendor(ctx, cln, uri, VendorInfo{
+			Targets: c.StringSlice("target"),
+			Tidy:    false,
 		})
 	},
 }
@@ -65,17 +69,23 @@ var moduleVendorCommand = &cli.Command{
 var moduleTidyCommand = &cli.Command{
 	Name:      "tidy",
 	Usage:     "add missing and remove unused modules",
-	ArgsUsage: "<*.hlb>",
+	ArgsUsage: "<uri>",
 	Action: func(c *cli.Context) error {
+		uri := DefaultHLBFilename
+		if c.NArg() > 1 {
+			return fmt.Errorf("expected at most 1 arg but got %d", c.NArg())
+		} else if c.NArg() == 1 {
+			uri = c.Args().First()
+		}
+
 		cln, ctx, err := hlb.Client(Context(), c.String("addr"))
 		if err != nil {
 			return err
 		}
+		ctx = hlb.WithDefaultContext(ctx, cln)
 
-		return Vendor(ctx, cln, VendorInfo{
-			Args:      c.Args().Slice(),
-			Tidy:      true,
-			ErrOutput: os.Stderr,
+		return Vendor(ctx, cln, uri, VendorInfo{
+			Tidy: true,
 		})
 	},
 }
@@ -83,7 +93,7 @@ var moduleTidyCommand = &cli.Command{
 var moduleTreeCommand = &cli.Command{
 	Name:      "tree",
 	Usage:     "print the tree of imported modules",
-	ArgsUsage: "<*.hlb>",
+	ArgsUsage: "<uri>",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:  "long",
@@ -91,39 +101,38 @@ var moduleTreeCommand = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
+		uri := DefaultHLBFilename
+		if c.NArg() > 1 {
+			return fmt.Errorf("expected at most 1 arg but got %d", c.NArg())
+		} else if c.NArg() == 1 {
+			uri = c.Args().First()
+		}
+
 		cln, ctx, err := hlb.Client(Context(), c.String("addr"))
 		if err != nil {
 			return err
 		}
+		ctx = hlb.WithDefaultContext(ctx, cln)
 
-		return Tree(ctx, cln, TreeInfo{
-			Args:      c.Args().Slice(),
-			Long:      c.Bool("long"),
-			ErrOutput: os.Stderr,
+		return Tree(ctx, cln, uri, TreeInfo{
+			Long: c.Bool("long"),
 		})
 	},
 }
 
 type VendorInfo struct {
-	Args      []string
-	Targets   []string
-	Tidy      bool
-	ErrOutput io.Writer
+	Targets []string
+	Tidy    bool
+	Stdin   io.Reader
+	Stderr  io.Writer
 }
 
-func Vendor(ctx context.Context, cln *client.Client, info VendorInfo) (err error) {
-	rc, err := ModuleReadCloser(info.Args)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-
-		rc, err = findVendoredModule(err, info.Args[0])
-		if err != nil {
-			return err
-		}
-	} else {
-		defer rc.Close()
+func Vendor(ctx context.Context, cln *client.Client, uri string, info VendorInfo) (err error) {
+	if info.Stdin == nil {
+		info.Stdin = os.Stdin
+	}
+	if info.Stderr == nil {
+		info.Stderr = os.Stderr
 	}
 
 	defer func() {
@@ -134,16 +143,28 @@ func Vendor(ctx context.Context, cln *client.Client, info VendorInfo) (err error
 		// Handle diagnostic errors.
 		spans := diagnostic.Spans(err)
 		for _, span := range spans {
-			fmt.Fprintf(info.ErrOutput, "%s\n", span.Pretty(ctx))
+			fmt.Fprintf(info.Stderr, "%s\n", span.Pretty(ctx))
 		}
 
 		err = errdefs.WithAbort(err, len(spans))
 	}()
 
-	ctx = filebuffer.WithBuffers(ctx, builtin.Buffers())
-	mod, err := parser.Parse(ctx, rc)
+	mod, err := ParseModuleURI(ctx, cln, info.Stdin, uri)
 	if err != nil {
-		return err
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		rc, err := findVendoredModule(err, uri)
+		if err != nil {
+			return err
+		}
+		defer rc.Close()
+
+		mod, err = parser.Parse(ctx, rc)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = checker.SemanticPass(mod)
@@ -224,17 +245,18 @@ func findVendoredModule(errNotExist error, name string) (io.ReadCloser, error) {
 }
 
 type TreeInfo struct {
-	Args      []string
-	Long      bool
-	ErrOutput io.Writer
+	Long   bool
+	Stdin  io.Reader
+	Stderr io.Writer
 }
 
-func Tree(ctx context.Context, cln *client.Client, info TreeInfo) (err error) {
-	rc, err := ModuleReadCloser(info.Args)
-	if err != nil {
-		return err
+func Tree(ctx context.Context, cln *client.Client, uri string, info TreeInfo) (err error) {
+	if info.Stdin == nil {
+		info.Stdin = os.Stdin
 	}
-	defer rc.Close()
+	if info.Stderr == nil {
+		info.Stderr = os.Stderr
+	}
 
 	defer func() {
 		if err == nil {
@@ -244,14 +266,13 @@ func Tree(ctx context.Context, cln *client.Client, info TreeInfo) (err error) {
 		// Handle diagnostic errors.
 		spans := diagnostic.Spans(err)
 		for _, span := range spans {
-			fmt.Fprintf(info.ErrOutput, "%s\n", span.Pretty(ctx))
+			fmt.Fprintf(info.Stderr, "%s\n", span.Pretty(ctx))
 		}
 
 		err = errdefs.WithAbort(err, len(spans))
 	}()
 
-	ctx = filebuffer.WithBuffers(ctx, builtin.Buffers())
-	mod, err := parser.Parse(ctx, rc)
+	mod, err := ParseModuleURI(ctx, cln, info.Stdin, uri)
 	if err != nil {
 		return err
 	}

--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -180,7 +180,7 @@ func Run(ctx context.Context, cln *client.Client, uri string, info RunInfo) (err
 
 	// Always force plain output in debug mode so the prompts are displayed
 	// correctly
-	if info.Debug {
+	if info.Debug || uri == "-" {
 		info.LogOutput = "plain"
 	}
 
@@ -284,19 +284,6 @@ func Run(ctx context.Context, cln *client.Client, uri string, info RunInfo) (err
 
 func ParseModuleURI(ctx context.Context, cln *client.Client, stdin io.Reader, uri string) (*ast.Module, error) {
 	if uri == "-" {
-		// Validate the stdin is piping into hlb.
-		f, ok := stdin.(interface{ Stat() (os.FileInfo, error) })
-		if !ok {
-			return nil, fmt.Errorf("not a valid stdin")
-		}
-		fi, err := f.Stat()
-		if err != nil {
-			return nil, fmt.Errorf("not a valid stdin: %w", err)
-		}
-		if fi.Mode()&os.ModeNamedPipe == 0 {
-			return nil, fmt.Errorf("not a valid stdin")
-		}
-
 		return parser.Parse(ctx, &parser.NamedReader{
 			Reader: stdin,
 			Value:  "<stdin>",

--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 
@@ -13,14 +14,13 @@ import (
 	solvererrdefs "github.com/moby/buildkit/solver/errdefs"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/openllb/hlb"
-	"github.com/openllb/hlb/builtin"
 	"github.com/openllb/hlb/codegen"
 	"github.com/openllb/hlb/codegen/debug"
 	"github.com/openllb/hlb/diagnostic"
 	"github.com/openllb/hlb/errdefs"
 	"github.com/openllb/hlb/local"
 	"github.com/openllb/hlb/parser"
-	"github.com/openllb/hlb/pkg/filebuffer"
+	"github.com/openllb/hlb/parser/ast"
 	"github.com/openllb/hlb/pkg/steer"
 	"github.com/openllb/hlb/solver"
 	cli "github.com/urfave/cli/v2"
@@ -35,7 +35,7 @@ var (
 var runCommand = &cli.Command{
 	Name:      "run",
 	Usage:     "compiles and runs a hlb program",
-	ArgsUsage: "<*.hlb>",
+	ArgsUsage: "<uri>",
 	Flags: []cli.Flag{
 		&cli.StringSliceFlag{
 			Name:    "target",
@@ -67,18 +67,20 @@ var runCommand = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		rc, err := ModuleReadCloser(c.Args().Slice())
-		if err != nil {
-			return err
+		uri := DefaultHLBFilename
+		if c.NArg() > 1 {
+			return fmt.Errorf("expected at most 1 arg but got %d", c.NArg())
+		} else if c.NArg() == 1 {
+			uri = c.Args().First()
 		}
-		defer rc.Close()
 
 		cln, ctx, err := hlb.Client(Context(), c.String("addr"))
 		if err != nil {
 			return err
 		}
+		ctx = hlb.WithDefaultContext(ctx, cln)
 
-		return Run(ctx, cln, rc, RunInfo{
+		return Run(ctx, cln, uri, RunInfo{
 			Tree:            c.Bool("tree"),
 			Targets:         c.StringSlice("target"),
 			LLB:             c.Bool("llb"),
@@ -123,7 +125,7 @@ type RunInfo struct {
 	Arch    string
 }
 
-func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo) (err error) {
+func Run(ctx context.Context, cln *client.Client, uri string, info RunInfo) (err error) {
 	if len(info.Targets) == 0 {
 		info.Targets = []string{"default"}
 	}
@@ -190,7 +192,6 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo
 	// store Progress in context in case we need to synchronize output later
 	ctx = codegen.WithProgress(ctx, p)
 	ctx = codegen.WithMultiWriter(ctx, p.MultiWriter())
-	ctx = filebuffer.WithBuffers(ctx, builtin.Buffers())
 
 	defer func() {
 		if err == nil {
@@ -200,7 +201,7 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo
 		err = errdefs.WithAbort(err, numErrs)
 	}()
 
-	mod, err := parser.Parse(ctx, rc)
+	mod, err := ParseModuleURI(ctx, cln, info.Stdin, uri)
 	if err != nil {
 		return err
 	}
@@ -209,8 +210,6 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo
 	for _, target := range info.Targets {
 		targets = append(targets, codegen.Target{Name: target})
 	}
-
-	ctx = codegen.WithImageResolver(ctx, codegen.NewCachedImageResolver(cln))
 
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -274,23 +273,42 @@ func Run(ctx context.Context, cln *client.Client, rc io.ReadCloser, info RunInfo
 	return err
 }
 
-func ModuleReadCloser(args []string) (io.ReadCloser, error) {
-	if len(args) == 0 {
-		return os.Open(DefaultHLBFilename)
-	} else if args[0] == "-" {
-		fi, err := os.Stdin.Stat()
+func ParseModuleURI(ctx context.Context, cln *client.Client, stdin io.Reader, uri string) (*ast.Module, error) {
+	if uri == "-" {
+		// Validate the stdin is piping into hlb.
+		f, ok := stdin.(interface{ Stat() (os.FileInfo, error) })
+		if !ok {
+			return nil, fmt.Errorf("not a valid stdin")
+		}
+		fi, err := f.Stat()
+		if err != nil {
+			return nil, fmt.Errorf("not a valid stdin: %w", err)
+		}
+		if fi.Mode()&os.ModeNamedPipe == 0 {
+			return nil, fmt.Errorf("not a valid stdin")
+		}
+
+		return parser.Parse(ctx, &parser.NamedReader{
+			Reader: stdin,
+			Value:  "<stdin>",
+		})
+	}
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case "":
+		f, err := os.Open(uri)
 		if err != nil {
 			return nil, err
 		}
-
-		if fi.Mode()&os.ModeNamedPipe == 0 {
-			return nil, fmt.Errorf("must provide path to hlb module or pipe to stdin")
-		}
-
-		return os.Stdin, nil
+		return parser.Parse(ctx, f)
+	default:
+		return nil, fmt.Errorf("%q is not a valid module uri scheme", u.Scheme)
 	}
-
-	return os.Open(args[0])
 }
 
 func displayError(ctx context.Context, w io.Writer, err error, printBacktrace bool) (numErrs int) {

--- a/codegen/debug/tui.go
+++ b/codegen/debug/tui.go
@@ -485,7 +485,7 @@ func handleList(w io.Writer, s *codegen.State, stop ast.StopNode, args []string)
 			diagnostic.DisplayError(s.Ctx, w, spans, s.Err, true)
 		} else {
 			for _, span := range diagnostic.Spans(s.Err) {
-				fmt.Fprintf(w, "%s\n", span.Pretty(s.Ctx))
+				fmt.Fprintln(w, span.Pretty(s.Ctx))
 			}
 		}
 		return nil

--- a/hlb.go
+++ b/hlb.go
@@ -3,7 +3,7 @@ package hlb
 import (
 	"context"
 	"fmt"
-	"os"
+	"io"
 
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/identity"
@@ -29,7 +29,7 @@ func WithDefaultContext(ctx context.Context, cln *client.Client) context.Context
 }
 
 // Compile compiles targets in a module and returns a solver.Request.
-func Compile(ctx context.Context, cln *client.Client, mod *ast.Module, targets []codegen.Target) (solver.Request, error) {
+func Compile(ctx context.Context, cln *client.Client, w io.Writer, mod *ast.Module, targets []codegen.Target) (solver.Request, error) {
 	err := checker.SemanticPass(mod)
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func Compile(ctx context.Context, cln *client.Client, mod *ast.Module, targets [
 	err = linter.Lint(ctx, mod)
 	if err != nil {
 		for _, span := range diagnostic.Spans(err) {
-			fmt.Fprintln(os.Stderr, span.Pretty(ctx))
+			fmt.Fprintln(w, span.Pretty(ctx))
 		}
 	}
 

--- a/hlb.go
+++ b/hlb.go
@@ -7,15 +7,28 @@ import (
 
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/identity"
+	"github.com/openllb/hlb/builtin"
 	"github.com/openllb/hlb/checker"
 	"github.com/openllb/hlb/codegen"
 	"github.com/openllb/hlb/diagnostic"
 	"github.com/openllb/hlb/linter"
 	"github.com/openllb/hlb/module"
 	"github.com/openllb/hlb/parser/ast"
+	"github.com/openllb/hlb/pkg/filebuffer"
 	"github.com/openllb/hlb/solver"
 )
 
+// WithDefaultContext adds common context values to the context.
+func WithDefaultContext(ctx context.Context, cln *client.Client) context.Context {
+	ctx = ast.WithModules(ctx, ast.NewModules())
+	ctx = filebuffer.WithBuffers(ctx, builtin.Buffers())
+	if cln != nil {
+		ctx = codegen.WithImageResolver(ctx, codegen.NewCachedImageResolver(cln))
+	}
+	return ctx
+}
+
+// Compile compiles targets in a module and returns a solver.Request.
 func Compile(ctx context.Context, cln *client.Client, mod *ast.Module, targets []codegen.Target) (solver.Request, error) {
 	err := checker.SemanticPass(mod)
 	if err != nil {

--- a/parser/directory.go
+++ b/parser/directory.go
@@ -14,6 +14,9 @@ type localDirectory struct {
 	dgst digest.Digest
 }
 
+// NewLocalDirectory returns an ast.Directory representing a directory on the
+// local system. It is also used to abstract the difference between reading
+// remote modules that has been vendored.
 func NewLocalDirectory(root string, dgst digest.Digest) ast.Directory {
 	return &localDirectory{root, dgst}
 }

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -12,16 +12,16 @@ import (
 )
 
 func Parse(ctx context.Context, r io.Reader, opts ...filebuffer.Option) (*ast.Module, error) {
+	mod := &ast.Module{}
+	defer AssignDocStrings(mod)
+
 	name := lexer.NameOfReader(r)
 	if name == "" {
 		name = "<stdin>"
 	}
-	r = &NewlinedReader{Reader: r}
-
-	mod := &ast.Module{}
-	defer AssignDocStrings(mod)
-
 	fb := filebuffer.New(name, opts...)
+
+	r = &NewlinedReader{Reader: r}
 	r = io.TeeReader(r, fb)
 	defer func() {
 		if mod.Pos.Filename != "" {

--- a/solver/directory.go
+++ b/solver/directory.go
@@ -1,0 +1,123 @@
+package solver
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"path/filepath"
+
+	"github.com/docker/buildx/util/progress"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/client/llb"
+	gateway "github.com/moby/buildkit/frontend/gateway/client"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/parser/ast"
+	"github.com/openllb/hlb/pkg/llbutil"
+	"golang.org/x/sync/errgroup"
+)
+
+// NewRemoteDirectory returns an ast.Directory representing a directory backed
+// by a BuildKit gateway reference. Since gateway references only live while
+// the build session is running, the build only exits when the ast.Directory is
+// closed.
+func NewRemoteDirectory(ctx context.Context, cln *client.Client, pw progress.Writer, def *llb.Definition, root string, dgst digest.Digest, solveOpts []SolveOption, sessionOpts []llbutil.SessionOption) (ast.Directory, error) {
+	// Block constructing remoteDirectory until the graph is solved and assigned to
+	// ref.
+	resolved := make(chan struct{})
+
+	s, err := llbutil.NewSession(ctx, sessionOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	// ctx.Done keeps Build from exiting until remoteDirectory is closed.
+	// This ensures that cache keys and results from the build are not garbage
+	// collected while its still in use.
+	ctx, cancel := context.WithCancel(ctx)
+
+	g.Go(func() error {
+		return s.Run(ctx, cln.Dialer())
+	})
+
+	var ref gateway.Reference
+	g.Go(func() error {
+		return Build(ctx, cln, s, pw, func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+			dir, err := c.Solve(ctx, gateway.SolveRequest{
+				Definition: def.ToPB(),
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			ref, err = dir.SingleRef()
+			if err != nil {
+				return nil, err
+			}
+
+			close(resolved)
+			<-ctx.Done()
+			return gateway.NewResult(), nil
+		}, solveOpts...)
+	})
+
+	select {
+	case <-ctx.Done():
+		cancel()
+		return nil, g.Wait()
+	case <-resolved:
+		// If ref is nil, then an error has occurred when solving, clean up and
+		// return.
+		if ref == nil {
+			cancel()
+			return nil, g.Wait()
+		}
+	}
+
+	return &remoteDirectory{root, dgst, ref, g, ctx, cancel}, nil
+}
+
+type remoteDirectory struct {
+	root   string
+	dgst   digest.Digest
+	ref    gateway.Reference
+	g      *errgroup.Group
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (r *remoteDirectory) Path() string {
+	return r.root
+}
+
+func (r *remoteDirectory) Digest() digest.Digest {
+	return r.dgst
+}
+
+func (r *remoteDirectory) Open(filename string) (io.ReadCloser, error) {
+	_, err := r.ref.StatFile(r.ctx, gateway.StatRequest{
+		Path: filename,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := r.ref.ReadFile(r.ctx, gateway.ReadRequest{
+		Filename: filename,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &parser.NamedReader{
+		Reader: bytes.NewReader(data),
+		Value:  filepath.Join(r.root, filename),
+	}, nil
+}
+
+func (r *remoteDirectory) Close() error {
+	r.cancel()
+	return r.g.Wait()
+}


### PR DESCRIPTION
- Bring consistency of `info.Stdin`, `info.Stderr` to other commands
- Bring consistency of module parsing to other commands
- Allow extension of module URIs
- Refactor `remoteDirectory` to `solver.NewRemoteDirectory`

## Stdin handling
```sh
❯ hlb run -
fs default() {
    image "alpine"
}
#1 resolve image config for docker.io/library/alpine:latest
#1 DONE 0.4s

#2 docker-image://docker.io/library/alpine:latest
#2 CACHED
```

Use `Ctrl+D` to terminate stdin input.

```sh
❯ echo 'fs default() { image "alpine" }' | hlb run -
#1 resolve image config for docker.io/library/alpine:latest
#1 DONE 0.4s

#2 docker-image://docker.io/library/alpine:latest
#2 CACHED
```