### PR TITLE
Support URIs in import decl

### DIFF
--- a/cmd/hlb/command/lint.go
+++ b/cmd/hlb/command/lint.go
@@ -59,7 +59,7 @@ func Lint(ctx context.Context, cln *client.Client, uri string, info LintInfo) er
 		info.Stderr = os.Stderr
 	}
 
-	mod, err := hlb.ParseModuleURI(ctx, cln, info.Stdin, uri)
+	mod, err := ParseModuleURI(ctx, cln, info.Stdin, uri)
 	if err != nil {
 		return err
 	}

--- a/cmd/hlb/command/module.go
+++ b/cmd/hlb/command/module.go
@@ -143,7 +143,7 @@ func Vendor(ctx context.Context, cln *client.Client, uri string, info VendorInfo
 		err = errdefs.WithAbort(err, len(spans))
 	}()
 
-	mod, err := hlb.ParseModuleURI(ctx, cln, info.Stdin, uri)
+	mod, err := ParseModuleURI(ctx, cln, info.Stdin, uri)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return err
@@ -264,7 +264,7 @@ func Tree(ctx context.Context, cln *client.Client, uri string, info TreeInfo) (e
 		err = errdefs.WithAbort(err, len(spans))
 	}()
 
-	mod, err := hlb.ParseModuleURI(ctx, cln, info.Stdin, uri)
+	mod, err := ParseModuleURI(ctx, cln, info.Stdin, uri)
 	if err != nil {
 		return err
 	}

--- a/errdefs/errors.go
+++ b/errdefs/errors.go
@@ -239,8 +239,12 @@ func WithBindCacheMount(as, cache ast.Node) error {
 }
 
 func WithDockerEngineUnsupported(decl ast.Node) error {
+	err := fmt.Errorf("not supported by buildkit embedded in docker engine, use standalone buildkit")
+	if decl == nil {
+		return err
+	}
 	return decl.WithError(
-		fmt.Errorf("not supported by buildkit embedded in docker engine, use standalone buildkit"),
+		err,
 		decl.Spanf(diagnostic.Primary, "not supported by docker engine"),
 	)
 }

--- a/module/resolve.go
+++ b/module/resolve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/buildx/util/progress"
 	"github.com/moby/buildkit/client"
@@ -229,7 +230,7 @@ func resolveGraph(ctx context.Context, info *resolveGraphInfo, mod *ast.Module) 
 
 			g.Go(func() error {
 				ctx = codegen.WithProgramCounter(ctx, id.Expr)
-				imod, filename, err := info.cg.EmitImport(ctx, mod, id)
+				imod, err := info.cg.EmitImport(ctx, mod, id)
 				if err != nil {
 					return err
 				}
@@ -241,6 +242,7 @@ func resolveGraph(ctx context.Context, info *resolveGraphInfo, mod *ast.Module) 
 				}
 
 				if info.visitor != nil {
+					filename := strings.TrimPrefix(imod.Pos.Filename, imod.Directory.Path())
 					err = info.visitor(VisitInfo{
 						Parent:     mod,
 						Import:     imod,

--- a/parser/ast/ast.go
+++ b/parser/ast/ast.go
@@ -193,6 +193,7 @@ type Module struct {
 	Mixin
 	Scope     *Scope
 	Directory Directory
+	URI       string
 	Doc       *CommentGroup
 	Decls     []*Decl `parser:"@@*"`
 }


### PR DESCRIPTION
- `(*codegen.CodeGen).EmitImport` uses the same `ParseModuleURI`.

Example:
```hlb
import go from "git://github.com/openllb/hlb@master:/go.hlb"

fs default() {
	go.lint src
}

fs src() {
	local "." with includePatterns("**/*.go", "go.mod", "go.sum", ".golangci.yml", ".git", "**/*.json")
}
```