### PR TITLE
Fix missing semaphore error check

### DIFF
--- a/solver/solve.go
+++ b/solver/solve.go
@@ -252,7 +252,9 @@ func Build(ctx context.Context, c *client.Client, s *session.Session, pw progres
 
 	limiter := ConcurrencyLimiter(ctx)
 	if limiter != nil {
-		limiter.Acquire(ctx, 1)
+		if err := limiter.Acquire(ctx, 1); err != nil {
+			return err
+		}
 	}
 
 	var (


### PR DESCRIPTION
This could lead to a panic if the semaphore could not be acquired due to
the context being cancelled, but the `Release` below was still reached.