### PR TITLE
Temporarily disable async register setting

### DIFF
--- a/codegen/value.go
+++ b/codegen/value.go
@@ -48,7 +48,14 @@ type register struct {
 
 func NewRegister(ctx context.Context) Register {
 	return &register{
-		debug: GetDebugger(ctx) != nil,
+		// Temporarily disable async sets.
+		// TODO: Revert this once async register behavior is stable.
+		// Currently, it seems to cause complexity explosions with
+		// thousands of goroutines, lots of memory use, and major
+		// contention on the concurrency limit with some complex graphs.
+		//debug: GetDebugger(ctx) != nil,
+		debug: true,
+
 		value: ZeroValue(ctx),
 		ctor: func(iface interface{}) (Value, error) {
 			return NewValue(ctx, iface)


### PR DESCRIPTION
We've been seeing problems that appear to be tied to the new async ref
resolution behavior. Some complex build graphs spawn thousands of
goroutines, use large amounts of memory, and get stuck contending on the
build concurrency limit. Unfortunately, we haven't been able to come up
with a repro case so far. My hunch is that maybe the asynchronous
behavior bypasses some important caching and causes a complexity
explosion (or there is some other bug causing the symptoms...).

Unless someone is interested in digging into this further, my proposal
is to disable asynchronous register setting for now to fix HLB master.
I'm planning to test this PR, and if I confirm it solves the problem, we
can consider merging it.