### PR TITLE
remove async solves for remote-directories

### DIFF
--- a/module/resolve_test.go
+++ b/module/resolve_test.go
@@ -56,10 +56,6 @@ func (r *testDirectory) Stat(filename string) (os.FileInfo, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
 
-func (r *testDirectory) Close() error {
-	return nil
-}
-
 func TestResolveGraph(t *testing.T) {
 	t.Parallel()
 

--- a/parser/ast/ast.go
+++ b/parser/ast/ast.go
@@ -179,8 +179,6 @@ type Directory interface {
 	Open(filename string) (io.ReadCloser, error)
 
 	Stat(filename string) (os.FileInfo, error)
-
-	Close() error
 }
 
 // Module represents a HLB source file. HLB is file-scoped, so every file

--- a/parser/directory.go
+++ b/parser/directory.go
@@ -47,5 +47,3 @@ func (r *localDirectory) Stat(filename string) (os.FileInfo, error) {
 	}
 	return os.Stat(filepath.Join(r.root, filename))
 }
-
-func (r *localDirectory) Close() error { return nil }


### PR DESCRIPTION
The ast.Directory Close is never called, so that ends up holding
the Solves running for the entire build.  See:
https://github.com/openllb/hlb/pull/323#issuecomment-1190974238

For now removing Close from the interface until we can figure out how
to more narrowly scope the remote directory usage.  This also moves
the file lookups to be synchronous on use (so still lazy if never used).
This could have a large impact if we were to access many files from
the remote directory, but typically I think we use this to just
import the `module.hlb` file for a remote import.

Future optimizations might be to ref-count the solve so we can reuse
the single solve for the life time of all the files returned from
Directory.Open.