### PR TITLE
Override the solve error if ErrorHandler returns an error

### DIFF
--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -237,7 +237,7 @@ func Run(ctx context.Context, cln *client.Client, uri string, info RunInfo) (err
 		if err == nil {
 			return
 		}
-		numErrs := displayError(ctx, info.Stderr, err, info.Backtrace)
+		numErrs := DisplayError(ctx, info.Stderr, err, info.Backtrace)
 		err = errdefs.WithAbort(err, numErrs)
 	}()
 
@@ -327,7 +327,7 @@ func Run(ctx context.Context, cln *client.Client, uri string, info RunInfo) (err
 	return err
 }
 
-func displayError(ctx context.Context, w io.Writer, err error, printBacktrace bool) (numErrs int) {
+func DisplayError(ctx context.Context, w io.Writer, err error, printBacktrace bool) (numErrs int) {
 	spans := diagnostic.SourcesToSpans(ctx, solvererrdefs.Sources(err), err)
 	if len(spans) > 0 {
 		diagnostic.DisplayError(ctx, w, spans, err, printBacktrace)


### PR DESCRIPTION
Came across the issue when testing the `shell-on-error` implementation.

If the debugger returns the [`ErrDebugExit`](https://github.com/openllb/hlb/blob/master/codegen/debugger.go#L378) error, the error string gets [wrapped](https://github.com/moby/buildkit/blob/master/client/solve.go#L242) in the main solve goroutine after the gRPC call. Error check on `ErrDebugExit` fails [afterwards](https://github.com/openllb/hlb/blob/master/cmd/hlb/command/run.go#L324) because we lose the original error from the gRPC call.

This PR overrides the solve error to the original error, so the error check on `ErrDebugExit` succeeds.