### PR TITLE
Support extra env vars for the debug shell

### DIFF
--- a/codegen/debug/tui.go
+++ b/codegen/debug/tui.go
@@ -573,5 +573,5 @@ func handleExec(ctx context.Context, d codegen.Debugger, is *steer.InputSteerer,
 		color.Bold(strings.Join(args, " ")),
 	))
 
-	return d.Exec(ctx, pr, stdout, stderr, args...)
+	return d.Exec(ctx, pr, stdout, stderr, nil, args...)
 }

--- a/codegen/debugger.go
+++ b/codegen/debugger.go
@@ -59,7 +59,7 @@ type Debugger interface {
 	Terminate() error
 
 	// Exec starts a process in the current debugging state.
-	Exec(ctx context.Context, stdin io.ReadCloser, stdout, stderr io.Writer, args ...string) error
+	Exec(ctx context.Context, stdin io.ReadCloser, stdout, stderr io.Writer, extraEnv []string, args ...string) error
 }
 
 // DebugMode is a mode of the debugger that affects control flow.
@@ -238,7 +238,7 @@ func (d *debugger) Terminate() error {
 	return nil
 }
 
-func (d *debugger) Exec(ctx context.Context, stdin io.ReadCloser, stdout, stderr io.Writer, args ...string) error {
+func (d *debugger) Exec(ctx context.Context, stdin io.ReadCloser, stdout, stderr io.Writer, extraEnv []string, args ...string) error {
 	s, err := d.GetState()
 	if err != nil {
 		return err
@@ -258,7 +258,7 @@ func (d *debugger) Exec(ctx context.Context, stdin io.ReadCloser, stdout, stderr
 			cancel()
 		}()
 
-		return ExecWithSolveErr(ctx, ge.Client, se, stdin, stdout, stderr, args...)
+		return ExecWithSolveErr(ctx, ge.Client, se, stdin, stdout, stderr, extraEnv, args...)
 	}
 
 	fs, err := s.Value.Filesystem()
@@ -266,7 +266,7 @@ func (d *debugger) Exec(ctx context.Context, stdin io.ReadCloser, stdout, stderr
 		return err
 	}
 
-	return ExecWithFS(ctx, d.cln, fs, s.Options, stdin, stdout, stderr, args...)
+	return ExecWithFS(ctx, d.cln, fs, s.Options, stdin, stdout, stderr, extraEnv, args...)
 }
 
 func (d *debugger) sendControl(control DebugMode, direction Direction) {


### PR DESCRIPTION
The `env []string` support was removed from `ExecWithSolveErr` in #286. Adding it back because it's required in newt.

This PR adds `env []string` to the client-facing `Exec` method, instead of the underlying implementation (`ExecWithSolveErr` or `ExecWithFS`).