### PR TITLE
Exit early on ErrDebugExit after Solve

### DIFF
--- a/codegen/debugger.go
+++ b/codegen/debugger.go
@@ -320,6 +320,10 @@ func (d *debugger) yield(ctx context.Context, scope *ast.Scope, node ast.Node, v
 
 		err = req.Solve(ctx, d.cln, MultiWriter(ctx))
 		if err != nil {
+			// If debugger has an error, continue to exit.
+			if d.err != nil {
+				return d.err
+			}
 			yieldErr = ProgramCounter(ctx).WithError(err)
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue where the debugger would hang at [`d.mode = <-d.control`](https://github.com/openllb/hlb/blob/master/codegen/debugger.go#L369) if `d.mode` is already `DebugTerminate`, and there is no more `control` value from the channel.