### PR TITLE
Add platform prefix to MultiWriter

### DIFF
--- a/solver/multiwriter.go
+++ b/solver/multiwriter.go
@@ -17,9 +17,15 @@ type MultiWriter struct {
 	claimedVerticesMu  sync.Mutex
 }
 
-func NewMultiWriter(pw progress.Writer) *MultiWriter {
+func NewMultiWriter(pw progress.Writer, prefix ...string) *MultiWriter {
 	if pw == nil {
 		return nil
+	}
+
+	for _, p := range prefix {
+		if p != "" {
+			pw = progress.WithPrefix(pw, p, true)
+		}
 	}
 
 	return &MultiWriter{

--- a/solver/progress.go
+++ b/solver/progress.go
@@ -32,6 +32,7 @@ type progressInfo struct {
 	writer    io.Writer
 	console   Console
 	logOutput logOutput
+	prefixes  []string
 }
 
 type logOutput int
@@ -53,6 +54,13 @@ func WithLogOutputTTY(con Console) ProgressOption {
 	return func(info *progressInfo) error {
 		info.console = con
 		info.logOutput = logOutputTTY
+		return nil
+	}
+}
+
+func WithLogPrefix(pfx ...string) ProgressOption {
+	return func(info *progressInfo) error {
+		info.prefixes = append(info.prefixes, pfx...)
 		return nil
 	}
 }
@@ -91,7 +99,7 @@ func NewProgress(ctx context.Context, opts ...ProgressOption) (Progress, error) 
 	p := &progressUI{
 		origCtx: ctx,
 		spp:     spp,
-		mw:      NewMultiWriter(spp),
+		mw:      NewMultiWriter(spp, info.prefixes...),
 		done:    make(chan struct{}),
 	}
 	p.g, p.ctx = errgroup.WithContext(p.origCtx)


### PR DESCRIPTION
This PR adds a platform prefix to Buildkit progress output, because the output is confusing when Newt solves multi-platform builds in parallel. However, the current implementation doesn't cover all output in plain mode. Buildkit doesn't give us a way to inject prefixes to the rest of the progress output:
- https://github.com/moby/buildkit/blob/master/util/progress/progressui/printer.go#L131
- https://github.com/moby/buildkit/blob/master/util/progress/progressui/printer.go#L198

Progress output with the current implementation:

![Screen Shot 2022-08-11 at 4 07 09 PM](https://user-images.githubusercontent.com/3825009/184256974-9c79fe2c-c610-41c9-a57a-69476b7880ba.png)

Let me know what you think, or if you have any suggestions.