### PR TITLE
Set implicit local directory path to ""

### DIFF
--- a/cmd/hlb/command/run.go
+++ b/cmd/hlb/command/run.go
@@ -116,7 +116,7 @@ func ParseModuleURI(ctx context.Context, cln *client.Client, stdin io.Reader, ur
 			Value:  "<stdin>",
 		})
 	}
-	dir := parser.NewLocalDirectory(".", "")
+	dir := parser.NewLocalDirectory("", "")
 	return codegen.ParseModuleURI(ctx, cln, dir, uri)
 }
 

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -33,7 +33,7 @@ func Parse(ctx context.Context, r io.Reader, opts ...filebuffer.Option) (*ast.Mo
 	if err != nil {
 		return nil, err
 	}
-	mod.Directory = NewLocalDirectory(".", "")
+	mod.Directory = NewLocalDirectory("", "")
 	ast.Modules(ctx).Set(mod.Pos.Filename, mod)
 	return mod, nil
 }


### PR DESCRIPTION
Previously, this was being set to ".", and would wrongly strip the first
"." from a path that begins with "." in `ModuleDir`. Setting it to the
empty string seems more correct: nothing will be stripped. The only
other use of this "root" is in `filepath.Join` calls inside `localDirectory`
methods, which will also do the right thing with an empty string.

Fixes #332