### PR TITLE
[WIP] Fix bogus session ID specified for "local" op

### DIFF
--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -241,7 +241,7 @@ func (l Local) Call(ctx context.Context, cln *client.Client, val Value, opts Opt
 	}
 	localOpts = append(localOpts, llb.SharedKeyHint(id))
 
-	sessionID := SessionID(ctx)
+	sessionID := solver.SessionID(ctx)
 	if sessionID != "" {
 		localOpts = append(localOpts, llb.SessionID(sessionID))
 	}
@@ -300,6 +300,7 @@ func (f Frontend) Call(ctx context.Context, cln *client.Client, val Value, opts 
 		return nil, err
 	}
 
+	ctx = solver.WithSessionID(ctx, s.ID())
 	g, ctx := errgroup.WithContext(ctx)
 
 	fs, err := ZeroValue(ctx).Filesystem()

--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -300,7 +300,6 @@ func (f Frontend) Call(ctx context.Context, cln *client.Client, val Value, opts 
 		return nil, err
 	}
 
-	ctx = solver.WithSessionID(ctx, s.ID())
 	g, ctx := errgroup.WithContext(ctx)
 
 	fs, err := ZeroValue(ctx).Filesystem()

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -59,7 +59,7 @@ func LocalState(ctx context.Context, t *testing.T, localPath string, opts ...llb
 		llb.SharedKeyHint(id),
 	}, opts...)
 
-	sessionID := codegen.SessionID(ctx)
+	sessionID := solver.SessionID(ctx)
 	if sessionID != "" {
 		opts = append(opts, llb.SessionID(sessionID))
 	}
@@ -987,7 +987,7 @@ func TestCodeGen(t *testing.T) {
 			}
 
 			cg := codegen.New(nil, nil)
-			ctx = codegen.WithSessionID(ctx, identity.NewID())
+			ctx = solver.WithSessionID(ctx, identity.NewID())
 			request, err := cg.Generate(ctx, mod, targets)
 			require.NoError(t, err, tc.name)
 
@@ -1057,7 +1057,7 @@ func TestCodegenError(t *testing.T) {
 			}
 
 			cg := codegen.New(nil, nil)
-			ctx = codegen.WithSessionID(ctx, identity.NewID())
+			ctx = solver.WithSessionID(ctx, identity.NewID())
 			_, err = cg.Generate(ctx, mod, targets)
 			var expected error
 			if tc.fn != nil {

--- a/codegen/context.go
+++ b/codegen/context.go
@@ -27,7 +27,6 @@ type (
 	returnTypeKey      struct{}
 	argKey             struct{ n int }
 	bindingKey         struct{}
-	sessionIDKey       struct{}
 	multiwriterKey     struct{}
 	imageResolverKey   struct{}
 	backtraceKey       struct{}
@@ -97,15 +96,6 @@ func WithArg(ctx context.Context, n int, arg ast.Node) context.Context {
 func Arg(ctx context.Context, n int) ast.Node {
 	arg, _ := ctx.Value(argKey{n}).(ast.Node)
 	return arg
-}
-
-func WithSessionID(ctx context.Context, sessionID string) context.Context {
-	return context.WithValue(ctx, sessionIDKey{}, sessionID)
-}
-
-func SessionID(ctx context.Context) string {
-	sessionID, _ := ctx.Value(sessionIDKey{}).(string)
-	return sessionID
 }
 
 func WithMultiWriter(ctx context.Context, mw *solver.MultiWriter) context.Context {

--- a/codegen/gateway_exec.go
+++ b/codegen/gateway_exec.go
@@ -80,6 +80,7 @@ func ExecWithFS(ctx context.Context, cln *client.Client, fs Filesystem, opts Opt
 	if err != nil {
 		return err
 	}
+	ctx = solver.WithSessionID(ctx, s.ID())
 
 	g, ctx := errgroup.WithContext(ctx)
 

--- a/codegen/resolver.go
+++ b/codegen/resolver.go
@@ -68,6 +68,7 @@ func (r *cachedImageResolver) ResolveImageConfig(ctx context.Context, ref string
 	if err != nil {
 		return
 	}
+	ctx = solver.WithSessionID(ctx, s.ID())
 
 	g, ctx := errgroup.WithContext(ctx)
 

--- a/hlb.go
+++ b/hlb.go
@@ -6,7 +6,6 @@ import (
 	"io"
 
 	"github.com/moby/buildkit/client"
-	"github.com/moby/buildkit/identity"
 	"github.com/openllb/hlb/builtin"
 	"github.com/openllb/hlb/checker"
 	"github.com/openllb/hlb/codegen"
@@ -56,7 +55,6 @@ func Compile(ctx context.Context, cln *client.Client, w io.Writer, mod *ast.Modu
 	}
 
 	cg := codegen.New(cln, resolver)
-	ctx = codegen.WithSessionID(ctx, identity.NewID())
 	if solver.ConcurrencyLimiter(ctx) == nil {
 		ctx = solver.WithConcurrencyLimiter(ctx, semaphore.NewWeighted(defaultMaxConcurrency))
 	}

--- a/solver/context.go
+++ b/solver/context.go
@@ -6,7 +6,10 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-type concurrencyLimiterKey struct{}
+type (
+	concurrencyLimiterKey struct{}
+	sessionIDKey          struct{}
+)
 
 func WithConcurrencyLimiter(ctx context.Context, limiter *semaphore.Weighted) context.Context {
 	return context.WithValue(ctx, concurrencyLimiterKey{}, limiter)
@@ -15,4 +18,13 @@ func WithConcurrencyLimiter(ctx context.Context, limiter *semaphore.Weighted) co
 func ConcurrencyLimiter(ctx context.Context) *semaphore.Weighted {
 	limiter, _ := ctx.Value(concurrencyLimiterKey{}).(*semaphore.Weighted)
 	return limiter
+}
+
+func WithSessionID(ctx context.Context, sessionID string) context.Context {
+	return context.WithValue(ctx, sessionIDKey{}, sessionID)
+}
+
+func SessionID(ctx context.Context) string {
+	sessionID, _ := ctx.Value(sessionIDKey{}).(string)
+	return sessionID
 }

--- a/solver/directory.go
+++ b/solver/directory.go
@@ -62,8 +62,8 @@ func (r *remoteDirectory) Open(filename string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	g, ctx := errgroup.WithContext(r.ctx)
+	ctx := WithSessionID(r.ctx, s.ID())
+	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
 		return s.Run(ctx, r.cln.Dialer())

--- a/solver/request.go
+++ b/solver/request.go
@@ -63,6 +63,7 @@ func (r *singleRequest) Solve(ctx context.Context, cln *client.Client, mw *Multi
 	if err != nil {
 		return err
 	}
+	ctx = WithSessionID(ctx, s.ID())
 
 	g, ctx := errgroup.WithContext(ctx)
 


### PR DESCRIPTION
The session ID specified was a randomly generated ID rather than the actual session ID. This casued a 5 second delay for every "local" op because of this code that tries to wait for the specified session: https://github.com/moby/buildkit/blob/abde08a5531d809a395cf648a31bca932b009af0/source/local/local.go#L95-L101