### PR TITLE
Provide registry creds to image resolver

### DIFF
--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openllb/hlb/errdefs"
 	"github.com/openllb/hlb/local"
 	"github.com/openllb/hlb/parser"
+	"github.com/openllb/hlb/pkg/imageutil"
 	"github.com/openllb/hlb/pkg/llbutil"
 	"github.com/openllb/hlb/pkg/stargzutil"
 	"github.com/openllb/hlb/solver"
@@ -761,7 +762,7 @@ func (dp DockerPush) Call(ctx context.Context, cln *client.Client, val Value, op
 		// keep mixed layers.
 		forceCompression := false
 		if exportFS.Image.Canonical != nil {
-			resolver := docker.NewResolver(docker.ResolverOptions{})
+			resolver := docker.NewResolver(docker.ResolverOptions{Credentials: imageutil.RegistryCreds})
 			forceCompression, err = stargzutil.HasNonStargzLayer(ctx, resolver, platforms.Only(exportFS.Platform), exportFS.Image.Canonical.String())
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Previously, HLB never provided credentials to image resolvers, so image resolution wouldn't work against registries that require authentication. This shims standard buildkit authprovider to provide credentials based on the local Docker configuration, so we reuse that logic instead of copy/pasting it.