### PR TITLE
use ForceNoOutput for mounts that are not bound

### DIFF
--- a/codegen/builtin_option.go
+++ b/codegen/builtin_option.go
@@ -707,6 +707,8 @@ func (m Mount) Call(ctx context.Context, cln *client.Client, val Value, opts Opt
 			return nil, errdefs.WithBindCacheMount(Binding(ctx).Bind.As, cache)
 		}
 		retOpts = append(retOpts, &Mount{Bind: mountpoint, Image: input.Image})
+	} else {
+		opts = append(opts, llb.ForceNoOutput)
 	}
 
 	retOpts = append(retOpts, &llbutil.MountRunOption{


### PR DESCRIPTION
We dont care about mutations to mounts unless they are bound with `as name` syntax.  However, buildkit does not know this so it assumes that mounts are mutable and will may be used elsewhere, so anytime we use a mount (including `local`) it will prevent buildkit from caching the vertex.