### PR TITLE
os/arch now required by buildkit on image spec

### DIFF
--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -761,6 +761,13 @@ func (dp DockerPush) Call(ctx context.Context, cln *client.Client, val Value, op
 	}
 	exportFS.Image.ContainerConfig.Labels = exportFS.Image.Config.Labels
 
+	if exportFS.Image.OS == "" {
+		exportFS.Image.OS = exportFS.Platform.OS
+	}
+	if exportFS.Image.Architecture == "" {
+		exportFS.Image.Architecture = exportFS.Platform.Architecture
+	}
+
 	var dgst string
 	exportFS.SolveOpts = append(exportFS.SolveOpts,
 		solver.WithImageSpec(exportFS.Image),


### PR DESCRIPTION
Related buildkit change:
https://github.com/moby/buildkit/pull/4601