### PR TITLE
default os/arch for image export

### DIFF
--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -761,11 +761,20 @@ func (dp DockerPush) Call(ctx context.Context, cln *client.Client, val Value, op
 	}
 	exportFS.Image.ContainerConfig.Labels = exportFS.Image.Config.Labels
 
-	if exportFS.Image.OS == "" {
+	defaultPlat := DefaultPlatform(ctx)
+	switch {
+	case exportFS.Image.OS != "": // all good
+	case exportFS.Platform.OS != "":
 		exportFS.Image.OS = exportFS.Platform.OS
+	default:
+		exportFS.Image.OS = defaultPlat.OS
 	}
-	if exportFS.Image.Architecture == "" {
+	switch {
+	case exportFS.Image.Architecture != "": // all good
+	case exportFS.Platform.Architecture != "":
 		exportFS.Image.Architecture = exportFS.Platform.Architecture
+	default:
+		exportFS.Image.Architecture = defaultPlat.Architecture
 	}
 
 	var dgst string


### PR DESCRIPTION
More defaulting is required to fix same issues as #354 where os/arch is required by buildkit