### PR TITLE
default os/arch for image export via docker load

### DIFF
--- a/codegen/builtin_fs.go
+++ b/codegen/builtin_fs.go
@@ -968,6 +968,22 @@ func (dl DockerLoad) Call(ctx context.Context, cln *client.Client, val Value, op
 		return nil, err
 	}
 
+	defaultPlat := DefaultPlatform(ctx)
+	switch {
+	case exportFS.Image.OS != "": // all good
+	case exportFS.Platform.OS != "":
+		exportFS.Image.OS = exportFS.Platform.OS
+	default:
+		exportFS.Image.OS = defaultPlat.OS
+	}
+	switch {
+	case exportFS.Image.Architecture != "": // all good
+	case exportFS.Platform.Architecture != "":
+		exportFS.Image.Architecture = exportFS.Platform.Architecture
+	default:
+		exportFS.Image.Architecture = defaultPlat.Architecture
+	}
+
 	for _, opt := range opts {
 		switch o := opt.(type) {
 		case solver.SolveOption:


### PR DESCRIPTION
More defaulting is required to fix same issues as #354 where os/arch is required by buildkit